### PR TITLE
commit issue #264

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/useSwitchNetwork.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useSwitchNetwork.ts
@@ -1,15 +1,24 @@
+const getChainId = (network: string): string => {
+  switch (network) {
+    case "mainnet":
+      return "SN_MAIN";
+    case "devnet":
+      return "SN_GOERLI";
+    default:
+      return `SN_${network.toUpperCase()}`;
+  }
+};
+
 export const useSwitchNetwork = () => {
   return {
     switchNetwork: async (network: string) => {
-      // @ts-ignore
+      // @ts-expect-error: Assert that window.starknet exists and isConnected is a boolean
       if (window.starknet && window.starknet.isConnected) {
-        // @ts-ignore
+        // @ts-expect-error: Assert that window.starknet.request is a function and the parameters match
         await window.starknet.request({
           type: "wallet_switchStarknetChain",
           params: {
-            chainId: `SN_${
-              network == "mainnet" ? "MAIN" : network.toUpperCase()
-            }`,
+            chainId: getChainId(network),
           },
         });
       }


### PR DESCRIPTION
# Task name here

Fixes #relevant-issue-here

## Types of change

- [ ] Feature
- [x] Bug
- [ ] Enhancement

## Comments (optional)
**1. Devnet on StarkNet is Often Based on Goerli Testnet**
-   StarkNet primarily uses two networks for testing environments:
-   Goerli Testnet (SN_GOERLI): This is a public test network for StarkNet that simulates mainnet conditions but uses test ETH from the Goerli testnet.
-   Devnet: Typically, StarkNet’s development environment (devnet) is based on Goerli. This means that if you’re using "devnet," you’re essentially operating in a Goerli-like environment with slight modifications for development purposes.

**2. Why "devnet" is Mapped to "SN_GOERLI"**
  - When developers work with StarkNet, they usually develop and test on the Goerli Testnet because it provides an environment similar to the mainnet, but without real costs and lower risks.
  - Although there could be a separate network called "devnet," StarkNet treats Goerli Testnet as the primary testing environment. Hence, in many cases, devnet is essentially a clone of Goerli with specific development tweaks.
  - This explains why "devnet" is mapped to "SN_GOERLI" instead of "SN_DEVNET". This is how StarkNet unifies testing and development environments to ensure consistency.
