### PR TITLE
feat: Add tabs to display Read and Write methods in Debug Contracts page

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 // @refresh reset
-import { useReducer } from "react";
+import { useReducer, useState } from "react";
 import { ContractReadMethods } from "./ContractReadMethods";
 // import { ContractWriteMethods } from "./ContractWriteMethods";
 import { Address, Balance } from "~~/components/scaffold-stark";
@@ -27,6 +27,7 @@ export const ContractUI = ({
   contractName,
   className = "",
 }: ContractUIProps) => {
+  const [activeTab, setActiveTab] = useState("read");
   const [refreshDisplayVariables, triggerRefreshDisplayVariables] = useReducer(
     (value) => !value,
     false,
@@ -34,6 +35,11 @@ export const ContractUI = ({
   const { targetNetwork } = useTargetNetwork();
   const { data: deployedContractData, isLoading: deployedContractLoading } =
     useDeployedContractInfo(contractName);
+
+  const tabs = [
+    { id: 'read', label: 'Read' },
+    { id: 'write', label: 'Write' }
+  ];
 
   if (deployedContractLoading) {
     return (
@@ -89,33 +95,33 @@ export const ContractUI = ({
             />
           </div>
         </div>
+
         <div className="col-span-1 lg:col-span-2 flex flex-col gap-6">
-          <div className="z-10">
-            <div className="rounded-[5px] border border-[#8A45FC] flex flex-col mt-10 relative bg-component">
-              <div className="bg-function w-[140px] h-[32.5px] absolute self-start -top-[43px] -left-[1px] -z-10 py-[0.55rem] clip-corner">
-                <div className="flex items-center justify-center space-x-2">
-                  <p className="my-0 text-sm text-center">Read</p>
-                </div>
-              </div>
-              <div className="p-5 divide-y divide-secondary">
-                <ContractReadMethods
-                  deployedContractData={deployedContractData}
-                />
-              </div>
-            </div>
+          <div className="tabs">
+            {tabs.map((tab) => (
+              <a
+                  key={tab.id}
+                  className={`tab h-10 ${activeTab === tab.id ? 'tab-active' : ''}`}
+                  onClick={() => setActiveTab(tab.id)}
+              >
+              {tab.label}
+              </a>
+            ))}
           </div>
           <div className="z-10">
-            <div className="rounded-[5px] border border-[#8A45FC] flex flex-col mt-10 relative bg-component">
-              <div className="w-[140px] h-[32.5px] absolute self-start -top-[43px] -left-[1px] -z-10 py-[0.55rem]  bg-function clip-corner">
-                <div className="flex items-center justify-center space-x-2">
-                  <p className="my-0 text-sm">Write</p>
-                </div>
-              </div>
+            <div className="rounded-[5px] border border-[#8A45FC] flex flex-col relative bg-component">
               <div className="p-5 divide-y divide-secondary">
-                <ContractWriteMethods
-                  deployedContractData={deployedContractData}
-                  onChange={triggerRefreshDisplayVariables}
-                />
+                {activeTab === "read" && (
+                  <ContractReadMethods
+                    deployedContractData={deployedContractData}
+                  />
+                )}
+                {activeTab === "write" && (
+                  <ContractWriteMethods
+                    deployedContractData={deployedContractData}
+                    onChange={triggerRefreshDisplayVariables}
+                  />
+                )}
               </div>
             </div>
           </div>

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -104,11 +104,11 @@ export const ContractUI = ({
         </div>
 
         <div className="col-span-1 lg:col-span-2 flex flex-col gap-6">
-          <div className="tabs tabs-boxed border border-[#8A45FC]">
+          <div className="tabs tabs-boxed border border-[#8A45FC] rounded-[5px]">
             {tabs.map((tab) => (
               <a
                 key={tab.id}
-                className={`tab h-10 ${activeTab === tab.id ? "tab-active !bg-[#8A45FC]" : ""}`}
+                className={`tab h-10 ${activeTab === tab.id ? "tab-active !bg-[#8A45FC] !rounded-[5px]" : ""}`}
                 onClick={() => setActiveTab(tab.id)}
               >
                 {tab.label}

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -97,7 +97,7 @@ export const ContractUI = ({
         </div>
 
         <div className="col-span-1 lg:col-span-2 flex flex-col gap-6">
-          <div className="tabs tabs-boxed">
+          <div className="tabs tabs-boxed border border-[#8A45FC]">
             {tabs.map((tab) => (
               <a
                   key={tab.id}

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -104,7 +104,7 @@ export const ContractUI = ({
         </div>
 
         <div className="col-span-1 lg:col-span-2 flex flex-col gap-6">
-          <div className="tabs tabs-boxed border border-[#8A45FC] rounded-[5px]">
+          <div className="tabs tabs-boxed border border-[#8A45FC] rounded-[5px] bg-transparent">
             {tabs.map((tab) => (
               <a
                 key={tab.id}

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -104,11 +104,11 @@ export const ContractUI = ({
         </div>
 
         <div className="col-span-1 lg:col-span-2 flex flex-col gap-6">
-          <div className="tabs tabs-bordered">
+          <div className="tabs tabs-boxed border border-[#8A45FC]">
             {tabs.map((tab) => (
               <a
                 key={tab.id}
-                className={`tab h-10 ${activeTab === tab.id ? "tab-active !bg-[#8b45fd5e]" : ""}`}
+                className={`tab h-10 ${activeTab === tab.id ? "tab-active !bg-[#8A45FC]" : ""}`}
                 onClick={() => setActiveTab(tab.id)}
               >
                 {tab.label}

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -97,7 +97,7 @@ export const ContractUI = ({
         </div>
 
         <div className="col-span-1 lg:col-span-2 flex flex-col gap-6">
-          <div className="tabs tabs-boxed">
+          <div className="tabs tabs-bordered">
             {tabs.map((tab) => (
               <a
                   key={tab.id}

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -97,11 +97,11 @@ export const ContractUI = ({
         </div>
 
         <div className="col-span-1 lg:col-span-2 flex flex-col gap-6">
-          <div className="tabs tabs-boxed border border-[#8A45FC]">
+          <div className="tabs tabs-boxed">
             {tabs.map((tab) => (
               <a
                   key={tab.id}
-                  className={`tab h-10 ${activeTab === tab.id ? 'tab-active !bg-[#8A45FC]' : ''}`}
+                  className={`tab h-10 ${activeTab === tab.id ? 'tab-active !bg-[#8b45fd5e]' : ''}`}
                   onClick={() => setActiveTab(tab.id)}
               >
               {tab.label}

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -97,11 +97,11 @@ export const ContractUI = ({
         </div>
 
         <div className="col-span-1 lg:col-span-2 flex flex-col gap-6">
-          <div className="tabs">
+          <div className="tabs tabs-boxed">
             {tabs.map((tab) => (
               <a
                   key={tab.id}
-                  className={`tab h-10 ${activeTab === tab.id ? 'tab-active' : ''}`}
+                  className={`tab h-10 ${activeTab === tab.id ? 'tab-active !bg-[#8A45FC]' : ''}`}
                   onClick={() => setActiveTab(tab.id)}
               >
               {tab.label}

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -2,8 +2,8 @@
 
 // @refresh reset
 import { useReducer, useState } from "react";
+import dynamic from 'next/dynamic';
 import { ContractReadMethods } from "./ContractReadMethods";
-// import { ContractWriteMethods } from "./ContractWriteMethods";
 import { Address, Balance } from "~~/components/scaffold-stark";
 import {
   useDeployedContractInfo,
@@ -12,8 +12,11 @@ import {
 import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";
 import { ContractName } from "~~/utils/scaffold-stark/contract";
 import { ContractVariables } from "./ContractVariables";
-import { ContractWriteMethods } from "./ContractWriteMethods";
 import { ClassHash } from "~~/components/scaffold-stark/ClassHash";
+
+const ContractWriteMethods = dynamic(() => import("./ContractWriteMethods").then(mod => mod.ContractWriteMethods), {
+  loading: () => <p>Loading Write Methods...</p>,
+});
 
 type ContractUIProps = {
   contractName: ContractName;

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -108,7 +108,7 @@ export const ContractUI = ({
             {tabs.map((tab) => (
               <a
                 key={tab.id}
-                className={`tab h-10 ${activeTab === tab.id ? "tab-active !bg-[#8A45FC] !rounded-[5px]" : ""}`}
+                className={`tab h-10 ${activeTab === tab.id ? "tab-active !bg-[#8A45FC] !rounded-[5px] !text-white" : ""}`}
                 onClick={() => setActiveTab(tab.id)}
               >
                 {tab.label}

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -2,7 +2,7 @@
 
 // @refresh reset
 import { useReducer, useState } from "react";
-import dynamic from 'next/dynamic';
+import dynamic from "next/dynamic";
 import { ContractReadMethods } from "./ContractReadMethods";
 import { Address, Balance } from "~~/components/scaffold-stark";
 import {
@@ -14,9 +14,13 @@ import { ContractName } from "~~/utils/scaffold-stark/contract";
 import { ContractVariables } from "./ContractVariables";
 import { ClassHash } from "~~/components/scaffold-stark/ClassHash";
 
-const ContractWriteMethods = dynamic(() => import("./ContractWriteMethods").then(mod => mod.ContractWriteMethods), {
-  loading: () => <p>Loading Write Methods...</p>,
-});
+const ContractWriteMethods = dynamic(
+  () =>
+    import("./ContractWriteMethods").then((mod) => mod.ContractWriteMethods),
+  {
+    loading: () => <p>Loading Write Methods...</p>,
+  },
+);
 
 type ContractUIProps = {
   contractName: ContractName;
@@ -40,8 +44,8 @@ export const ContractUI = ({
     useDeployedContractInfo(contractName);
 
   const tabs = [
-    { id: 'read', label: 'Read' },
-    { id: 'write', label: 'Write' }
+    { id: "read", label: "Read" },
+    { id: "write", label: "Write" },
   ];
 
   if (deployedContractLoading) {
@@ -103,11 +107,11 @@ export const ContractUI = ({
           <div className="tabs tabs-bordered">
             {tabs.map((tab) => (
               <a
-                  key={tab.id}
-                  className={`tab h-10 ${activeTab === tab.id ? 'tab-active !bg-[#8b45fd5e]' : ''}`}
-                  onClick={() => setActiveTab(tab.id)}
+                key={tab.id}
+                className={`tab h-10 ${activeTab === tab.id ? "tab-active !bg-[#8b45fd5e]" : ""}`}
+                onClick={() => setActiveTab(tab.id)}
               >
-              {tab.label}
+                {tab.label}
               </a>
             ))}
           </div>


### PR DESCRIPTION
# Separate Read and Write Tabs in Debug Contracts

Fixes https://github.com/Scaffold-Stark/scaffold-stark-2/issues/281

## Short description of the solution
Replaced the separate `Read` and `Write` sections with a single tabbed interface using [DaisyUI's](https://daisyui.com/components/tab/) tabs.

Also, as suggested in the issue made use of [next/dynamic](https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading) to lazy load the content of the `Write` tab

## Types of change

- [ ] Feature
- [ ] Bug
- [X] Enhancement

## Comments (optional)
NOTE for reviewers: As mentioned in the telegram channel there are many styles for the tabs. On this PR I added 4 different commits with 4 different proposals. Here is what each of them looks like, please let me know which one you like the most to either remove the other commits or just apply the change of the option you like the most. And also, if you have another proposal please let me know

### Option 1
<img width="1036" alt="Screenshot 2024-09-28 at 2 30 04 PM" src="https://github.com/user-attachments/assets/671790e1-d41e-4e22-a3b9-20e37135fcd5">

### Option 2
<img width="1037" alt="Screenshot 2024-09-28 at 2 30 24 PM" src="https://github.com/user-attachments/assets/559ad8e0-3ef6-4af8-8d36-a5ced1396540">

### Option 3
<img width="1035" alt="Screenshot 2024-09-28 at 2 29 04 PM" src="https://github.com/user-attachments/assets/371d8e1a-02bf-4d44-baa3-3213b01eb652">

### Option 4
<img width="1047" alt="Screenshot 2024-09-28 at 2 26 36 PM" src="https://github.com/user-attachments/assets/0bae83ea-2cfd-4474-a558-d6fd1a0a386c">

### How it was before (for reference)
<img width="1064" alt="Screenshot 2024-09-28 at 1 48 12 PM" src="https://github.com/user-attachments/assets/01907e3a-8334-42c6-8430-221cfd0e86df">

