### PR TITLE
feat: Add verification contract command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:nextjs": "yarn workspace @ss-2/nextjs test",
     "format": "yarn workspace @ss-2/nextjs format && yarn workspace @ss-2/snfoundry format",
     "format:check": "yarn workspace @ss-2/nextjs format:check && yarn workspace @ss-2/snfoundry format:check",
-    "prepare": "husky"
+    "prepare": "husky",
+    "verify": "yarn workspace @ss-2/snfoundry verify"
   },
   "packageManager": "yarn@3.2.3",
   "devDependencies": {

--- a/packages/snfoundry/package.json
+++ b/packages/snfoundry/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write 'scripts-ts/**/*.{ts,tsx}' && cd contracts && scarb fmt",
     "format:check": "prettier --check 'scripts-ts/**/*.{ts,tsx}' && cd contracts && scarb fmt --check",
     "postinstall": "shx cp -n .env.example .env",
-    "deploy:verify": "ts-node scripts-ts/verify-contracts.ts"
+    "verify": "ts-node scripts-ts/verify-contracts.ts"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/packages/snfoundry/package.json
+++ b/packages/snfoundry/package.json
@@ -10,7 +10,8 @@
     "compile": "cd contracts && scarb build",
     "format": "prettier --write 'scripts-ts/**/*.{ts,tsx}' && cd contracts && scarb fmt",
     "format:check": "prettier --check 'scripts-ts/**/*.{ts,tsx}' && cd contracts && scarb fmt --check",
-    "postinstall": "shx cp -n .env.example .env"
+    "postinstall": "shx cp -n .env.example .env",
+    "deploy:verify": "ts-node scripts-ts/verify-contracts.ts"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/packages/snfoundry/scripts-ts/verify-contracts.ts
+++ b/packages/snfoundry/scripts-ts/verify-contracts.ts
@@ -1,44 +1,51 @@
 import path from 'path';
 import { execSync } from 'child_process';
 import yargs from 'yargs';
+
 // Import deployedContracts
 import deployedContracts from '../../nextjs/contracts/deployedContracts';
 
-// Parse command line arguments
-const argv = yargs(process.argv.slice(2))
-  .option('network', {
-    type: 'string',
-    description: 'Specify the network mainnet or sepolia',
-    demandOption: true,
-  })
-  .parseSync();
+function main() {
+  // Parse command line arguments
+  const argv = yargs(process.argv.slice(2))
+    .option('network', {
+      type: 'string',
+      description: 'Specify the network mainnet or sepolia',
+      demandOption: true,
+    })
+    .parseSync();
 
-const network = argv.network;
+  const network = argv.network;
 
-if (!deployedContracts[network]) {
-  console.error(`No deployed contracts found for network: ${network}`);
-  process.exit(1);
+  if (!deployedContracts[network]) {
+    console.error(`No deployed contracts found for network: ${network}`);
+    process.exit(1);
+  }
+
+  // Change to the contracts directory
+  const contractsDir = path.resolve(__dirname, '../contracts');
+  process.chdir(contractsDir);
+
+  // Verify each contract
+  Object.entries(deployedContracts[network]).forEach(([contractName, contractInfo]: [string, any]) => {
+    const { address } = contractInfo;
+    
+    console.log(`Verifying ${contractName} on ${network}...`);
+    
+    try {
+      execSync(
+        `sncast verify --contract-address ${address} --contract-name ${contractName} --network ${network} --verifier walnut --confirm-verification`,
+        { stdio: 'inherit' }
+      );
+      console.log(`Successfully verified ${contractName}`);
+    } catch (error) {
+      console.error(`Failed to verify ${contractName}:`, error);
+    }
+  });
+
+  console.log('Verification process completed.');
 }
 
-// Change to the contracts directory
-const contractsDir = path.resolve(__dirname, '../contracts');
-process.chdir(contractsDir);
-
-// Verify each contract
-Object.entries(deployedContracts[network]).forEach(([contractName, contractInfo]: [string, any]) => {
-  const { address } = contractInfo;
-  
-  console.log(`Verifying ${contractName} on ${network}...`);
-  
-  try {
-    execSync(
-      `sncast verify --contract-address ${address} --contract-name ${contractName} --network ${network} --verifier walnut --confirm-verification` ,
-      { stdio: 'inherit' }
-    );
-    console.log(`Successfully verified ${contractName}`);
-  } catch (error) {
-    console.error(`Failed to verify ${contractName}:`, error);
-  }
-});
-
-console.log('Verification process completed.');
+if (typeof module !== "undefined" && require.main === module) {
+  main();
+}

--- a/packages/snfoundry/scripts-ts/verify-contracts.ts
+++ b/packages/snfoundry/scripts-ts/verify-contracts.ts
@@ -1,10 +1,8 @@
 import path from 'path';
 import { execSync } from 'child_process';
 import yargs from 'yargs';
-
 // Import deployedContracts
-const deployedContractsPath = path.resolve(__dirname, '../../nextjs/contracts/deployedContracts');
-const deployedContracts = require(deployedContractsPath).default;
+import deployedContracts from '../../nextjs/contracts/deployedContracts';
 
 // Parse command line arguments
 const argv = yargs(process.argv.slice(2))

--- a/packages/snfoundry/scripts-ts/verify-contracts.ts
+++ b/packages/snfoundry/scripts-ts/verify-contracts.ts
@@ -1,0 +1,46 @@
+import path from 'path';
+import { execSync } from 'child_process';
+import yargs from 'yargs';
+
+// Import deployedContracts
+const deployedContractsPath = path.resolve(__dirname, '../../nextjs/contracts/deployedContracts');
+const deployedContracts = require(deployedContractsPath).default;
+
+// Parse command line arguments
+const argv = yargs(process.argv.slice(2))
+  .option('network', {
+    type: 'string',
+    description: 'Specify the network mainnet or sepolia',
+    demandOption: true,
+  })
+  .parseSync();
+
+const network = argv.network;
+
+if (!deployedContracts[network]) {
+  console.error(`No deployed contracts found for network: ${network}`);
+  process.exit(1);
+}
+
+// Change to the contracts directory
+const contractsDir = path.resolve(__dirname, '../contracts');
+process.chdir(contractsDir);
+
+// Verify each contract
+Object.entries(deployedContracts[network]).forEach(([contractName, contractInfo]: [string, any]) => {
+  const { address } = contractInfo;
+  
+  console.log(`Verifying ${contractName} on ${network}...`);
+  
+  try {
+    execSync(
+      `sncast verify --contract-address ${address} --contract-name ${contractName} --network ${network} --verifier walnut` ,
+      { stdio: 'inherit' }
+    );
+    console.log(`Successfully verified ${contractName}`);
+  } catch (error) {
+    console.error(`Failed to verify ${contractName}:`, error);
+  }
+});
+
+console.log('Verification process completed.');

--- a/packages/snfoundry/scripts-ts/verify-contracts.ts
+++ b/packages/snfoundry/scripts-ts/verify-contracts.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { execSync } from 'child_process';
 import yargs from 'yargs';
 import fs from 'fs';
+import { green, red, yellow } from "./helpers/colorize-log";
 
 // Import deployedContracts
 import deployedContracts from '../../nextjs/contracts/deployedContracts';
@@ -29,7 +30,7 @@ function main() {
   
   // Remove comments and extract contract names
   const contractsToVerify = deployFileContent
-    .replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '')
+    .replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '') 
     .match(/contract:\s*"([^"]+)"/g)
     ?.map(match => match.split('"')[1]) || [];
 
@@ -41,22 +42,19 @@ function main() {
   Object.entries(deployedContracts[network]).forEach(([contract, contractInfo]: [string, any]) => {
     if (contractsToVerify.includes(contract)) {
       const { address } = contractInfo;
-      
-      console.log(`Verifying ${contract} on ${network}...`);
-      
+      console.log(yellow(`Verifying ${contract} on ${network}...`));
       try {
         execSync(
           `sncast verify --contract-address ${address} --contract-name ${contract} --network ${network} --verifier walnut --confirm-verification`,
           { stdio: 'inherit' }
         );
-        console.log(`Successfully verified ${contract}`);
+        console.log(green("Successfully verified"), contract);
       } catch (error) {
-        console.error(`Failed to verify ${contract}:`, error);
+        console.error(red(`Failed to verify ${contract}:`), error);
       }
     }
   });
-
-  console.log('Verification process completed.');
+  console.log(green("✅ Verification process completed."));
 }
 
 if (typeof module !== "undefined" && require.main === module) {

--- a/packages/snfoundry/scripts-ts/verify-contracts.ts
+++ b/packages/snfoundry/scripts-ts/verify-contracts.ts
@@ -34,7 +34,7 @@ Object.entries(deployedContracts[network]).forEach(([contractName, contractInfo]
   
   try {
     execSync(
-      `sncast verify --contract-address ${address} --contract-name ${contractName} --network ${network} --verifier walnut` ,
+      `sncast verify --contract-address ${address} --contract-name ${contractName} --network ${network} --verifier walnut --confirm-verification` ,
       { stdio: 'inherit' }
     );
     console.log(`Successfully verified ${contractName}`);


### PR DESCRIPTION
# Add verification contract command #288 

Fixes #288 

## Types of change

- [x] Feature
- [ ] Bug
- [ ] Enhancement

## Comments 
A new command is added that allows verifying the deployed contract from the `deployedContracts.ts` file on Walnut.dev.  The following parameter must be included:

--network: sepolia or mainnet

For example:

`yarn verify --network sepolia`