### PR TITLE
Test: Add unit test for useScaffoldContract and useScaffoldReadContract

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldContract.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldContract.test.ts
@@ -1,0 +1,112 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useScaffoldContract } from "~~/hooks/scaffold-stark/useScaffoldContract";
+import { useDeployedContractInfo } from "~~/hooks/scaffold-stark/useDeployedContractInfo";
+import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";
+import { useAccount } from "~~/hooks/useAccount";
+import { Contract, RpcProvider } from "starknet";
+
+import type { Mock } from "vitest";
+import { ContractName } from "~~/utils/scaffold-stark/contract";
+
+//Using vitest's functionality to mock modules from different paths
+vi.mock("~~/hooks/scaffold-stark/useDeployedContractInfo");
+vi.mock("~~/hooks/scaffold-stark/useTargetNetwork");
+vi.mock("~~/hooks/useAccount");
+vi.mock("starknet", () => {
+  const actualStarknet = vi.importActual("starknet");
+  return {
+    ...actualStarknet,
+    Contract: vi.fn(),
+    RpcProvider: vi.fn(),
+  };
+});
+
+describe("useScaffoldContract", () => {
+  const mockAbi = [
+    { type: "function", name: "mockFunction", inputs: [], outputs: [] },
+  ];
+  const mockAddress = "0x12345";
+  const contractName: ContractName = "Strk";
+
+  //Some necessary mocks
+  const mockedUseDeployedContractInfo =
+    useDeployedContractInfo as unknown as Mock;
+  const mockedUseTargetNetwork = useTargetNetwork as unknown as Mock;
+  const mockedUseAccount = useAccount as unknown as Mock;
+  const MockedContract = Contract as unknown as Mock;
+  const MockedRpcProvider = RpcProvider as unknown as Mock;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    mockedUseDeployedContractInfo.mockReturnValue({
+      data: {
+        abi: mockAbi,
+        address: mockAddress,
+      },
+      isLoading: false,
+    });
+
+    mockedUseTargetNetwork.mockReturnValue({
+      targetNetwork: {
+        rpcUrls: { public: { http: ["https://mock-rpc-url"] } },
+      },
+    });
+
+    mockedUseAccount.mockReturnValue({
+      account: {
+        address: "0x129846",
+      },
+    });
+
+    MockedContract.mockImplementation(() => ({
+      address: mockAddress,
+      abi: mockAbi,
+    }));
+
+    MockedRpcProvider.mockImplementation(() => ({
+      nodeAddress: "https://mock-rpc-url",
+    }));
+  });
+
+  it("should return a contract when deployedContractData is available", () => {
+    const { result } = renderHook(() => useScaffoldContract({ contractName }));
+
+    expect(result.current.data).toBeDefined();
+    expect(result.current.data?.address).toBe(mockAddress);
+    expect(result.current.data?.abi).toEqual(mockAbi);
+  });
+
+  it("should return undefined contract when deployedContractData is not available", () => {
+    mockedUseDeployedContractInfo.mockReturnValueOnce({
+      data: undefined,
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useScaffoldContract({ contractName }));
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("should create RpcProvider with the correct public URL", () => {
+    renderHook(() => useScaffoldContract({ contractName }));
+
+    expect(MockedRpcProvider).toHaveBeenCalledWith({
+      nodeUrl: "https://mock-rpc-url",
+    });
+  });
+
+  it("should set isLoading to true when deployed contract is loading", () => {
+    mockedUseDeployedContractInfo.mockReturnValueOnce({
+      data: undefined,
+      isLoading: true,
+    });
+
+    const { result } = renderHook(() => useScaffoldContract({ contractName }));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldReadContract.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldReadContract.test.ts
@@ -1,0 +1,103 @@
+import { renderHook } from "@testing-library/react";
+import { useScaffoldReadContract } from "../useScaffoldReadContract";
+import { useReadContract } from "@starknet-react/core";
+import { vi, describe, it, expect, Mock } from "vitest";
+
+// Mocking dependencies using Vitest
+vi.mock("~~/hooks/scaffold-stark", () => ({
+  useDeployedContractInfo: vi.fn(() => ({
+    data: {
+      address: "0x123",
+      abi: [{ name: "symbol" }],
+    },
+  })),
+}));
+
+vi.mock("@starknet-react/core", () => ({
+  useReadContract: vi.fn(),
+}));
+
+describe("useScaffoldReadContract", () => {
+  const contractName = "Eth"; // Using a valid contract name. we could use 'TestContract' here
+  const functionName = "symbol"; // Using a valid function name. we could actually use 'testFunction' here
+
+  const mockUseReadContract = useReadContract as unknown as Mock;
+
+  it("should call useReadContract with correct parameters when deployedContract is defined", () => {
+    mockUseReadContract.mockReturnValue({
+      data: "mockedData",
+    });
+
+    const filteredArgs = [1, undefined, 3].filter((arg) => arg !== undefined);
+
+    renderHook(() =>
+      useScaffoldReadContract({
+        contractName,
+        functionName,
+        args: filteredArgs, // Pass filtered args
+      }),
+    );
+
+    expect(mockUseReadContract).toHaveBeenCalledWith({
+      functionName: "symbol",
+      address: "0x123",
+      abi: [{ name: "symbol" }],
+      watch: true,
+      args: filteredArgs,
+      enabled: true,
+      blockIdentifier: "pending",
+    });
+  });
+
+  it("should disable read when args contain undefined", () => {
+    renderHook(() =>
+      useScaffoldReadContract({
+        contractName,
+        functionName,
+        args: [1, undefined, 3], // args with undefined
+      }),
+    );
+
+    expect(mockUseReadContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false, // The read should be disabled if args contain undefined
+      }),
+    );
+  });
+
+  it("should enable read when args do not contain undefined", () => {
+    const filteredArgs = [1, 2, 3];
+
+    renderHook(() =>
+      useScaffoldReadContract({
+        contractName,
+        functionName,
+        args: filteredArgs,
+      }),
+    );
+
+    expect(mockUseReadContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true, // The read should be enabled since args do not contain undefined, args was filtered
+      }),
+    );
+  });
+
+  it("should pass blockIdentifier as 'pending'", () => {
+    const filteredArgs = [1, 2];
+
+    renderHook(() =>
+      useScaffoldReadContract({
+        contractName,
+        functionName,
+        args: filteredArgs,
+      }),
+    );
+
+    expect(mockUseReadContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        blockIdentifier: "pending", // Ensure blockIdentifier is passed as 'pending'. using the default which is 'pending'
+      }),
+    );
+  });
+});


### PR DESCRIPTION
# Add Unit Tests for useScaffoldContract and useScaffoldReadContract

## Types of change

- [x] Feature
- [ ] Bug
- [ ] Enhancement

## Summary

This pull request introduces unit tests for the useScaffoldContract and useScaffoldReadContract hooks, ensuring they behave as expected in various scenarios. These tests cover:

- Correct behavior of the hooks under normal conditions.
### Test cases implemented for useScaffoldReadContract
- Ensuring useReadContract is called with the correct parameters.
- Ensuring that read is disabled when arguments contain undefined.
- Ensuring that read is enabled when arguments do not contain undefined.
- Passing block Identifier as pending (the default)
### Test cases implemented for useScaffoldContract
- Ensuring a contract is returned when deployedContractData is available.
- Ensuring that undefined contract is returned when deployedContractData is not available.
- Ensuring that RpcProvider is created with the correct public URL.
- Ensuring that isLoading is set to true when deployed contract is loading.

The tests are written using Vitest. 

## Comments
- I have also included tests for edge cases where arguments may be undefined.
- *All implemented test cases pass as expected both in my local device and outside* .
- used npm run test:nextjs to run my test
- Any feedback on improving the tests or additional cases to cover would be appreciated.

![Screenshot from 2024-10-04 23-36-25](https://github.com/user-attachments/assets/c849f42b-02dd-453f-a926-7ab8517f6700)


