### PR TITLE
Add yarn deploy --noreset and modify yarn deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "chain": "yarn workspace @ss-2/snfoundry chain",
     "deploy": "yarn workspace @ss-2/snfoundry deploy",
-    "deploy:noreset": "yarn workspace @ss-2/snfoundry deploy --noreset",
+    "deploy:no-reset": "yarn workspace @ss-2/snfoundry deploy --no-reset",
     "test": "yarn workspace @ss-2/snfoundry test",
     "compile": "yarn workspace @ss-2/snfoundry compile",
     "start": "yarn workspace @ss-2/nextjs dev",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "chain": "yarn workspace @ss-2/snfoundry chain",
     "deploy": "yarn workspace @ss-2/snfoundry deploy",
-    "deploy:reset": "yarn workspace @ss-2/snfoundry  deploy:reset",
+    "deploy:noreset": "yarn workspace @ss-2/snfoundry deploy --noreset",
     "test": "yarn workspace @ss-2/snfoundry test",
     "compile": "yarn workspace @ss-2/snfoundry compile",
     "start": "yarn workspace @ss-2/nextjs dev",

--- a/packages/snfoundry/package.json
+++ b/packages/snfoundry/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "chain": "starknet-devnet --seed 0 --account-class cairo1",
     "deploy": "ts-node scripts-ts/helpers/deploy-wrapper.ts",
-    "deploy:reset": "ts-node scripts-ts/helpers/deploy-wrapper.ts --reset",
+    "deploy:noreset": "yarn workspace @ss-2/snfoundry deploy --noreset",
     "test": "cd contracts && snforge test",
     "test-eslint": "node eslint-contract-name/eslint-plugin-contract-names.test.js",
     "compile": "cd contracts && scarb build",

--- a/packages/snfoundry/package.json
+++ b/packages/snfoundry/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "chain": "starknet-devnet --seed 0 --account-class cairo1",
     "deploy": "ts-node scripts-ts/helpers/deploy-wrapper.ts",
-    "deploy:noreset": "yarn workspace @ss-2/snfoundry deploy --noreset",
+    "deploy:no-reset": "yarn workspace @ss-2/snfoundry deploy --no-reset",
     "test": "cd contracts && snforge test",
     "test-eslint": "node eslint-contract-name/eslint-plugin-contract-names.test.js",
     "compile": "cd contracts && scarb build",

--- a/packages/snfoundry/scripts-ts/deploy-contract.ts
+++ b/packages/snfoundry/scripts-ts/deploy-contract.ts
@@ -18,7 +18,7 @@ import { getTxVersion } from "./helpers/fees";
 
 interface Arguments {
   network: string;
-  noreset: boolean;
+  reset: boolean;
   fee?: string;
   [x: string]: unknown;
   _: (string | number)[];
@@ -31,11 +31,12 @@ const argv = yargs(process.argv.slice(2))
     description: "Specify the network",
     demandOption: true,
   })
-  .option("noreset", {
+  .option("reset", {
     alias: "nr",
     type: "boolean",
-    description: "Do not reset deployments (keep existing deployments)",
-    default: false,
+    description:
+      "(--no-reset) Do not reset deployments (keep existing deployments)",
+    default: true,
   })
   .option("fee", {
     type: "string",
@@ -47,7 +48,7 @@ const argv = yargs(process.argv.slice(2))
   .parseSync() as Arguments;
 
 const networkName: string = argv.network;
-const resetDeployments: boolean = argv.noreset;
+const resetDeployments: boolean = argv.reset;
 const feeToken: string = argv.fee;
 
 let deployments = {};
@@ -57,7 +58,7 @@ const { provider, deployer }: Network = networks[networkName];
 
 const declareIfNot_NotWait = async (
   payload: DeclareContractPayload,
-  options?: UniversalDetails
+  options?: UniversalDetails,
 ) => {
   const declareContractPayload = extractContractHashes(payload);
   try {
@@ -68,7 +69,7 @@ const declareIfNot_NotWait = async (
       const txVersion = await getTxVersion(
         networks[networkName],
         feeToken,
-        isSierraContract
+        isSierraContract,
       );
       const { transaction_hash } = await deployer.declare(payload, {
         ...options,
@@ -95,7 +96,7 @@ const deployContract_NotWait = async (payload: {
   try {
     const { calls, addresses } = transaction.buildUDCCall(
       payload,
-      deployer.address
+      deployer.address,
     );
     deployCalls.push(...calls);
     return {
@@ -128,7 +129,7 @@ const deployContract_NotWait = async (payload: {
  * });
  */
 const deployContract = async (
-  params: DeployContractParams
+  params: DeployContractParams,
 ): Promise<{
   classHash: string;
   address: string;
@@ -157,10 +158,10 @@ const deployContract = async (
         .readFileSync(
           path.resolve(
             __dirname,
-            `../contracts/target/dev/contracts_${contract}.compiled_contract_class.json`
-          )
+            `../contracts/target/dev/contracts_${contract}.compiled_contract_class.json`,
+          ),
         )
-        .toString("ascii")
+        .toString("ascii"),
     );
   } catch (error) {
     if (
@@ -169,13 +170,13 @@ const deployContract = async (
       error.message.includes("compiled_contract_class")
     ) {
       const match = error.message.match(
-        /\/dev\/(.+?)\.compiled_contract_class/
+        /\/dev\/(.+?)\.compiled_contract_class/,
       );
       const missingContract = match ? match[1].split("_").pop() : "Unknown";
       console.error(
         red(
-          `The contract "${missingContract}" doesn't exist or is not compiled`
-        )
+          `The contract "${missingContract}" doesn't exist or is not compiled`,
+        ),
       );
     } else {
       console.error(red("Error reading compiled contract class file: "), error);
@@ -192,10 +193,10 @@ const deployContract = async (
         .readFileSync(
           path.resolve(
             __dirname,
-            `../contracts/target/dev/contracts_${contract}.contract_class.json`
-          )
+            `../contracts/target/dev/contracts_${contract}.contract_class.json`,
+          ),
         )
-        .toString("ascii")
+        .toString("ascii"),
     );
   } catch (error) {
     console.error(red("Error reading contract class file: "), error);
@@ -217,7 +218,7 @@ const deployContract = async (
       contract: compiledContractSierra,
       casm: compiledContractCasm,
     },
-    options
+    options,
   );
 
   let randomSalt = stark.randomAddress();
@@ -248,8 +249,8 @@ const executeDeployCalls = async (options?: UniversalDetails) => {
   if (deployCalls.length < 1) {
     throw new Error(
       red(
-        "Aborted: No contract to deploy. Please prepare the contracts with `deployContract`"
-      )
+        "Aborted: No contract to deploy. Please prepare the contracts with `deployContract`",
+      ),
     );
   }
 
@@ -281,7 +282,7 @@ const executeDeployCalls = async (options?: UniversalDetails) => {
 const loadExistingDeployments = () => {
   const networkPath = path.resolve(
     __dirname,
-    `../deployments/${networkName}_latest.json`
+    `../deployments/${networkName}_latest.json`,
   );
   if (fs.existsSync(networkPath)) {
     return JSON.parse(fs.readFileSync(networkPath, "utf8"));
@@ -292,16 +293,16 @@ const loadExistingDeployments = () => {
 const exportDeployments = () => {
   const networkPath = path.resolve(
     __dirname,
-    `../deployments/${networkName}_latest.json`
+    `../deployments/${networkName}_latest.json`,
   );
 
-  const resetDeployments: boolean = !argv.noreset;
+  const resetDeployments: boolean = argv.reset;
 
   if (!resetDeployments && fs.existsSync(networkPath)) {
     const currentTimestamp = new Date().getTime();
     fs.renameSync(
       networkPath,
-      networkPath.replace("_latest.json", `_${currentTimestamp}.json`)
+      networkPath.replace("_latest.json", `_${currentTimestamp}.json`),
     );
   }
 

--- a/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
+++ b/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
@@ -6,7 +6,7 @@ interface CommandLineOptions {
   _: string[]; // Non-hyphenated arguments are usually under the `_` key
   $0: string; // The script name or path is under the `$0` key
   network?: string; // The --network option
-  noreset?: boolean;
+  reset?: boolean;
   fee?: string;
 }
 
@@ -14,18 +14,20 @@ const argv = yargs(process.argv.slice(2))
   .options({
     network: { type: "string" },
     fee: { type: "string", choices: ["eth", "strk"], default: "eth" },
-    noreset: {
+    reset: {
       type: "boolean",
       description: "Do not reset deployments (keep existing deployments)",
-      default: false,
+      default: true,
     },
   })
   .parseSync() as CommandLineOptions;
 
+console.log(argv);
+
 // Set the NETWORK environment variable based on the --network argument
 process.env.NETWORK = argv.network || "devnet";
 process.env.FEE_TOKEN = argv.fee || "eth";
-process.env.NO_RESET = argv.noreset ? "true" : "false";
+process.env.NO_RESET = !argv.reset ? "true" : "false";
 
 // Execute the deploy script without the reset option
 try {
@@ -33,9 +35,9 @@ try {
     `cd contracts && scarb build && ts-node ../scripts-ts/deploy.ts` +
       ` --network ${process.env.NETWORK}` +
       ` --fee ${process.env.FEE_TOKEN}` +
-      ` --noreset ${process.env.NO_RESET}` +
+      ` --no-reset ${process.env.NO_RESET}` +
       ` && ts-node ../scripts-ts/helpers/parse-deployments.ts && cd ..`,
-    { stdio: "inherit" }
+    { stdio: "inherit" },
   );
 } catch (error) {
   console.error("Error during deployment:", error);

--- a/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
+++ b/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
@@ -6,32 +6,37 @@ interface CommandLineOptions {
   _: string[]; // Non-hyphenated arguments are usually under the `_` key
   $0: string; // The script name or path is under the `$0` key
   network?: string; // The --network option
-  reset?: boolean;
+  noreset?: boolean;
   fee?: string;
 }
 
 const argv = yargs(process.argv.slice(2))
   .options({
     network: { type: "string" },
-    reset: { type: "boolean", default: false },
     fee: { type: "string", choices: ["eth", "strk"], default: "eth" },
+    noreset: {
+      type: "boolean",
+      description: "Do not reset deployments (keep existing deployments)",
+      default: false,
+    },
   })
   .parseSync() as CommandLineOptions;
 
 // Set the NETWORK environment variable based on the --network argument
 process.env.NETWORK = argv.network || "devnet";
 process.env.FEE_TOKEN = argv.fee || "eth";
-// Set the RESET environment variable based on the --reset flag
+process.env.NO_RESET = argv.noreset ? "true" : "false";
 
-// Execute the deploy script
-execSync(
-  "cd contracts && scarb build && ts-node ../scripts-ts/deploy.ts" +
-    " --network " +
-    process.env.NETWORK +
-    " --fee " +
-    process.env.FEE_TOKEN +
-    (argv.reset ? " --reset" : "") +
-    " && ts-node ../scripts-ts/helpers/parse-deployments.ts" +
-    " && cd ..",
-  { stdio: "inherit" }
-);
+// Execute the deploy script without the reset option
+try {
+  execSync(
+    `cd contracts && scarb build && ts-node ../scripts-ts/deploy.ts` +
+      ` --network ${process.env.NETWORK}` +
+      ` --fee ${process.env.FEE_TOKEN}` +
+      ` --noreset ${process.env.NO_RESET}` +
+      ` && ts-node ../scripts-ts/helpers/parse-deployments.ts && cd ..`,
+    { stdio: "inherit" }
+  );
+} catch (error) {
+  console.error("Error during deployment:", error);
+}


### PR DESCRIPTION
# Add yarn deploy --noreset and modify yarn deploy

- Integrated and modified `yarn deploy` now always resets contracts.
- Integration of `yarn deploy --noreset`, this new command does not reset previous deployments.

Fixes #285 

## Types of change

- [x] Feature
- [x] Bug
- [x] Enhancement


