### PR TITLE
fix: wrong variables in scaffold write contract

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
@@ -76,7 +76,7 @@ export const useScaffoldWriteContract = <
   }) => {
     // if no args supplied, use the one supplied from hook
     let newArgs = params?.args;
-    if (!newArgs) {
+    if (Object.keys(newArgs || {}).length <= 0) {
       newArgs = args;
     }
 
@@ -100,7 +100,7 @@ export const useScaffoldWriteContract = <
         ? parseFunctionParams({
             abiFunction,
             abi: deployedContractData.abi,
-            inputs: args as any[],
+            inputs: newArgs as any[],
             isRead: false,
             isReadArgsParsing: false,
           }).flat(Infinity)


### PR DESCRIPTION
# Task name here

Issue where a wrong variable `newArgs` was incorrectly used in `useScaffoldWriteContract.

## Types of change

- [ ] Feature
- [X] Bug
- [ ] Enhancement

## Comments (optional)
