### PR TITLE
fix: use read contract watch mode does not work

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldReadContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldReadContract.ts
@@ -29,7 +29,7 @@ export const useScaffoldReadContract = <
     address: deployedContract?.address,
     abi: deployedContract?.abi,
     watch: true,
-    args,
+    args: args || [],
     enabled:
       args && (!Array.isArray(args) || !args.some((arg) => arg === undefined)),
     blockIdentifier: "pending" as BlockNumber,

--- a/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
+++ b/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
@@ -22,8 +22,6 @@ const argv = yargs(process.argv.slice(2))
   })
   .parseSync() as CommandLineOptions;
 
-console.log(argv);
-
 // Set the NETWORK environment variable based on the --network argument
 process.env.NETWORK = argv.network || "devnet";
 process.env.FEE_TOKEN = argv.fee || "eth";


### PR DESCRIPTION
# Task name here

In speedrun, there is the issue of "Cannot mint token of same id". This is caused by `useReadContract` not working properly if args is not defined. Fixed by adding a fallback `[]` if args is undefined

## Types of change

- [ ] Feature
- [X] Bug
- [ ] Enhancement

## Comments (optional)
