### PR TITLE
Solution in event issue

### DIFF
--- a/packages/nextjs/utils/scaffold-stark/contract.ts
+++ b/packages/nextjs/utils/scaffold-stark/contract.ts
@@ -458,10 +458,7 @@ const decodeParamsWithType = (paramType: string, param: any): unknown => {
         : `Err(${parseParamWithType(error, result.unwrap(), isRead)})`;
     }, param);
   } else if (isCairoContractAddress(paramType)) {
-    return tryParsingParamReturnObject(
-      getChecksumAddress,
-      `0x${param.toString(16)}`,
-    );
+    return tryParsingParamReturnObject(validateAndParseAddress, param);
   } else if (isCairoU256(paramType)) {
     return tryParsingParamReturnObject(uint256.uint256ToBN, param);
   } else if (isCairoByteArray(paramType)) {


### PR DESCRIPTION
# Solution in event issue

In the contract.ts file in the `decodeParamWithType` we have returned to the simpler version by removing `getChecksumAddress` and adding `validateAndParseAddress`.

Example Speedrun CH-0

![Captura desde 2024-10-17 22-07-43](https://github.com/user-attachments/assets/fcb1a012-4320-4fe9-8657-d889f69dca13)

## Types of change

- [x] Bug


