### PR TITLE
refactor(parser): use starknetjs parsers to encode decode data

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/Array.tsx
+++ b/packages/nextjs/app/debug/_components/contract/Array.tsx
@@ -74,16 +74,15 @@ export const ArrayInput = ({
                     nextInputObject = nextInputRecipe(parentForm!);
                   }
 
-                  const currentInputArray = { ...inputArr };
-
-                  // we do some nasty workaround
-                  currentInputArray[index] =
-                    nextInputObject?.[`input_${index}`] || null;
-
-                  setInputArr(currentInputArray);
+                  setInputArr((currentInputArray: any) => {
+                    return {
+                      ...currentInputArray,
+                      [index]: nextInputObject?.[index] || null,
+                    };
+                  });
                 }}
-                form={inputArr[index]}
-                stateObjectKey={`input_${index}`}
+                form={inputArr}
+                stateObjectKey={index}
                 paramType={
                   {
                     name: `${abiParameter.name}[${index}]`,

--- a/packages/nextjs/app/debug/_components/contract/ContractInput.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractInput.tsx
@@ -8,6 +8,7 @@ import {
   isCairoArray,
   isCairoBigInt,
   isCairoInt,
+  isCairoTuple,
   isCairoType,
   isCairoU256,
 } from "~~/utils/scaffold-stark";
@@ -58,6 +59,11 @@ export const ContractInput = ({
           setFormErrorMessage={setFormErrorMessage}
         />
       );
+    }
+
+    // we prio tuples here to avoid wrong input
+    else if (isCairoTuple(paramType.type)) {
+      return <InputBase {...inputProps} />;
     } else if (
       isCairoInt(paramType.type) ||
       isCairoBigInt(paramType.type) ||

--- a/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
@@ -7,12 +7,12 @@ import {
   displayTxResult,
   getFunctionInputKey,
   getInitialFormState,
-  getParsedContractFunctionArgs,
+  getArgsAsStringInputFromForm,
   transformAbiFunction,
 } from "~~/app/debug/_components/contract";
 import { AbiFunction } from "~~/utils/scaffold-stark/contract";
 import { BlockNumber } from "starknet";
-import { useReadContract } from "@starknet-react/core";
+import { useContract, useReadContract } from "@starknet-react/core";
 import { ContractInput } from "./ContractInput";
 
 type ReadOnlyFunctionFormProps = {
@@ -33,12 +33,17 @@ export const ReadOnlyFunctionForm = ({
   const [formErrorMessage, setFormErrorMessage] = useState<string | null>(null);
   const lastForm = useRef(form);
 
+  const { contract: contractInstance } = useContract({
+    abi,
+    address: contractAddress,
+  });
+
   const { isFetching, data, refetch, error } = useReadContract({
     address: contractAddress,
     functionName: abiFunction.name,
     abi: [...abi],
     args: inputValue || [],
-    enabled: !!inputValue,
+    enabled: !!inputValue && !!contractInstance,
     blockIdentifier: "pending" as BlockNumber,
   });
 
@@ -66,8 +71,7 @@ export const ReadOnlyFunctionForm = ({
   });
 
   const handleRead = () => {
-    const newInputValue = getParsedContractFunctionArgs(form, false, true);
-
+    const newInputValue = getArgsAsStringInputFromForm(form, false, true);
     if (JSON.stringify(form) !== JSON.stringify(lastForm.current)) {
       setInputValue(newInputValue);
       lastForm.current = form;

--- a/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
+++ b/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
@@ -90,7 +90,6 @@ export const getArgsAsStringInputFromForm = (
     // array
     if (isCairoArray(key)) {
       const genericType = parseGenericType(key)[0];
-      console.log({ genericType });
       return value.map((arrayValue: any) =>
         _encodeValueFromKey(genericType, arrayValue),
       );

--- a/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
+++ b/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
@@ -1,14 +1,22 @@
+import { cairo, CairoCustomEnum } from "starknet";
+import {
+  isCairoBigInt,
+  isCairoBool,
+  isCairoFelt,
+  isCairoInt,
+  isCairoTuple,
+} from "~~/utils/scaffold-stark";
 import {
   AbiEnum,
   AbiFunction,
   AbiParameter,
   AbiStruct,
-  deepParseValues,
+  parseTuple,
 } from "~~/utils/scaffold-stark/contract";
 /**
  * Generates a key based on function metadata
  */
-const getFunctionInputKey = (
+export const getFunctionInputKey = (
   functionName: string,
   input: AbiParameter,
   inputIndex: number,
@@ -17,7 +25,7 @@ const getFunctionInputKey = (
   return functionName + "_" + name + "_" + input.type;
 };
 
-const getInitialTupleFormState = (abiParameter: AbiStruct | AbiEnum) => {
+export const getInitialTupleFormState = (abiParameter: AbiStruct | AbiEnum) => {
   const initialForm: Record<string, any> = {};
 
   if (abiParameter.type === "struct") {
@@ -34,7 +42,7 @@ const getInitialTupleFormState = (abiParameter: AbiStruct | AbiEnum) => {
   return initialForm;
 };
 
-const getInitialFormState = (abiFunction: AbiFunction) => {
+export const getInitialFormState = (abiFunction: AbiFunction) => {
   const initialForm: Record<string, any> = {};
   if (!abiFunction.inputs) return initialForm;
   abiFunction.inputs.forEach((input, inputIndex) => {
@@ -44,18 +52,101 @@ const getInitialFormState = (abiFunction: AbiFunction) => {
   return initialForm;
 };
 
+const convertStringInputToBool = (input: string) => {
+  if (new Set(["true", "1", "0x1", "0x01, 0x001"]).has(input)) {
+    return true;
+  } else if (new Set(["false", "0", "0x0", "0x00", "0x000"]).has(input)) {
+    return false;
+  }
+
+  return true;
+};
+
+function isValidNumber(input?: string): boolean {
+  // Check for empty string
+  if ((input || "").length === 0) return false;
+
+  // Check if it's a valid hex number (starts with '0x' or '0X')
+  if (/^0x[0-9a-fA-F]+$/i.test(input || "")) {
+    return true;
+  }
+
+  // Check for a valid decimal number (including scientific notation and floating points)
+  const decimalNumberRegex = /^[-+]?(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?$/;
+  return decimalNumberRegex.test(input || "");
+}
+
 /**
  * parses form input with array support
  */
-const getParsedContractFunctionArgs = (
+export const getArgsAsStringInputFromForm = (
   form: Record<string, any>,
   isRead: boolean,
   isReadArgsParsing?: boolean,
 ) => {
-  return Object.keys(form).map((key) => {
-    const valueOfArg = form[key];
-    return deepParseValues(valueOfArg, isRead, key, isReadArgsParsing);
-  });
+  const _encodeValueFromKey = (key: string = "", value: any): any => {
+    // translate boolean input
+    if (isCairoBool(key)) return convertStringInputToBool(value);
+
+    // encode tuple input
+    if (isCairoTuple(key)) return cairo.tuple(parseTuple(value));
+
+    if (
+      isValidNumber(value) &&
+      (isCairoBigInt(key) || isCairoInt(key) || isCairoFelt(key))
+    ) {
+      return parseInt(value, 16);
+    }
+
+    // enum & struct
+    if (key.includes("contracts::struct")) {
+      type FormStructValue = {
+        type: string;
+        value: any;
+      };
+
+      // alias it so that we have better name
+      const structObject = value;
+
+      // this indicates enum
+      if (Object.keys(structObject).includes("variant")) {
+        // construct empty enums
+        const enumObject = structObject.variant as any;
+        const enumVariants = Object.keys(enumObject);
+        const restructuredEnum = Object.fromEntries(
+          enumVariants.map((variant) => [
+            variant,
+            (enumObject[variant].value || "").trim().length > 0
+              ? _encodeValueFromKey(
+                  (enumObject[variant] as FormStructValue).type,
+                  (enumObject[variant] as FormStructValue).value,
+                )
+              : undefined,
+          ]),
+        );
+
+        return new CairoCustomEnum(restructuredEnum);
+      }
+
+      // map out values
+      const remappedEntries = Object.entries(structObject).map(
+        ([structObjectKey, structObjectValue]) => {
+          return [
+            structObjectKey,
+            _encodeValueFromKey(
+              (structObjectValue as FormStructValue).type,
+              (structObjectValue as FormStructValue).value,
+            ),
+          ];
+        },
+      );
+      return Object.fromEntries(remappedEntries);
+    }
+
+    return value;
+  };
+
+  return Object.keys(form).map((key) => _encodeValueFromKey(key, form[key]));
 };
 
 const adjustInput = (input: AbiParameter): AbiParameter => {
@@ -64,19 +155,11 @@ const adjustInput = (input: AbiParameter): AbiParameter => {
   };
 };
 
-const transformAbiFunction = (abiFunction: AbiFunction): AbiFunction => {
+export const transformAbiFunction = (abiFunction: AbiFunction): AbiFunction => {
   return {
     ...abiFunction,
     inputs: abiFunction.inputs.map((value) =>
       adjustInput(value as AbiParameter),
     ),
   };
-};
-
-export {
-  getFunctionInputKey,
-  getInitialFormState,
-  getInitialTupleFormState,
-  getParsedContractFunctionArgs,
-  transformAbiFunction,
 };

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
@@ -5,15 +5,12 @@ import {
   ContractName,
   contracts,
   ExtractAbiFunctionNamesScaffold,
-  getFunctionsByStateMutability,
-  parseFunctionParams,
   UseScaffoldArgsParam,
   UseScaffoldWriteConfig,
 } from "~~/utils/scaffold-stark/contract";
 import { useSendTransaction, useNetwork, Abi } from "@starknet-react/core";
 import { Contract as StarknetJsContract, InvocationsDetails } from "starknet";
 import { notification } from "~~/utils/scaffold-stark";
-import { useMemo } from "react";
 import { useTransactor } from "./useTransactor";
 
 export const useScaffoldMultiWriteContract = <
@@ -33,50 +30,6 @@ export const useScaffoldMultiWriteContract = <
   const { targetNetwork } = useTargetNetwork();
   const { chain } = useNetwork();
   const sendTxnWrapper = useTransactor();
-
-  // TODO: commented out in case we need it again
-  // const parsedCalls = useMemo(() => {
-  //   if (calls) {
-  //     return calls.map((call) => {
-  //       const functionName = call.functionName;
-  //       const contractName = call.contractName;
-  //       const unParsedArgs = call.args as any[];
-  //       const contract = contracts?.[targetNetwork.network]?.[
-  //         contractName as ContractName
-  //       ] as Contract<TContractName>;
-
-  //       // TODO: see if we still need this
-  //       // const abiFunction = getFunctionsByStateMutability(
-  //       //   contract?.abi || [],
-  //       //   "external",
-  //       // ).find((fn) => fn.name === functionName);
-
-  //       // we convert to starknetjs contract instance here since deployed data may be undefined if contract is not deployed
-  //       const contractInstance = new StarknetJsContract(
-  //         contract.abi,
-  //         contract.address,
-  //       );
-
-  //       return {
-  //         ...contractInstance.populate(functionName, unParsedArgs as any[]),
-
-  //         // TODO: see if we still need this
-  //         // calldata:
-  //         //   abiFunction && unParsedArgs && contract
-  //         //     ? parseFunctionParams({
-  //         //         abiFunction,
-  //         //         isRead: false,
-  //         //         inputs: unParsedArgs as any[],
-  //         //         isReadArgsParsing: false,
-  //         //         abi: contract.abi,
-  //         //       }).flat()
-  //         //     : [],
-  //       };
-  //     });
-  //   } else {
-  //     return [];
-  //   }
-  // }, [calls, targetNetwork.network]);
 
   // TODO add custom options
 

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback } from "react";
 import { useTargetNetwork } from "./useTargetNetwork";
 import {
   useDeployedContractInfo,
@@ -8,22 +8,11 @@ import {
   ContractAbi,
   ContractName,
   ExtractAbiFunctionNamesScaffold,
-  getFunctionsByStateMutability,
-  parseFunctionParams,
   UseScaffoldWriteConfig,
 } from "~~/utils/scaffold-stark/contract";
-import {
-  useSendTransaction,
-  useNetwork,
-  Abi,
-  useContract,
-} from "@starknet-react/core";
+import { useSendTransaction, useNetwork, Abi } from "@starknet-react/core";
 import { notification } from "~~/utils/scaffold-stark";
 import { Contract as StarknetJsContract } from "starknet";
-
-type UpdatedArgs = Parameters<
-  ReturnType<typeof useSendTransaction>["sendAsync"]
->[0];
 
 export const useScaffoldWriteContract = <
   TAbi extends Abi,
@@ -41,30 +30,6 @@ export const useScaffoldWriteContract = <
   const { chain } = useNetwork();
   const sendTxnWrapper = useTransactor();
   const { targetNetwork } = useTargetNetwork();
-
-  const abiFunction = useMemo(
-    () =>
-      getFunctionsByStateMutability(
-        deployedContractData?.abi || [],
-        "external",
-      ).find((fn) => fn.name === functionName),
-    [deployedContractData?.abi, functionName],
-  );
-
-  // TODO: see if we need this bit later
-  // const parsedParams = useMemo(() => {
-  //   if (args && abiFunction && deployedContractData) {
-  //     const parsed = parseFunctionParams({
-  //       abiFunction,
-  //       abi: deployedContractData.abi,
-  //       inputs: args as any[],
-  //       isRead: false,
-  //       isReadArgsParsing: true,
-  //     }).flat(Infinity);
-  //     return parsed;
-  //   }
-  //   return [];
-  // }, [args, abiFunction, deployedContractData]);
 
   // leave blank for now since default args will be called by the trigger function anyway
   const sendTransactionInstance = useSendTransaction({});
@@ -93,18 +58,6 @@ export const useScaffoldWriteContract = <
         console.error("You are on the wrong network");
         return;
       }
-
-      // TODO: see if we need this back, keeping this here
-      // let newParsedParams =
-      //   newArgs && abiFunction && deployedContractData
-      //     ? parseFunctionParams({
-      //         abiFunction,
-      //         abi: deployedContractData.abi,
-      //         inputs: newArgs as any[],
-      //         isRead: false,
-      //         isReadArgsParsing: false,
-      //       })
-      //     : parsedParams;
 
       // we convert to starknetjs contract instance here since deployed data may be undefined if contract is not deployed
       const contractInstance = new StarknetJsContract(

--- a/packages/nextjs/utils/scaffold-stark/contract.ts
+++ b/packages/nextjs/utils/scaffold-stark/contract.ts
@@ -863,7 +863,7 @@ function formatInputForParsing({
   );
 }
 
-function parseTuple(value: string): string[] {
+export function parseTuple(value: string): string[] {
   const values: string[] = [];
   let depth = 0;
   let current = "";

--- a/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
+++ b/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
@@ -22,8 +22,6 @@ const argv = yargs(process.argv.slice(2))
   })
   .parseSync() as CommandLineOptions;
 
-console.log(argv);
-
 // Set the NETWORK environment variable based on the --network argument
 process.env.NETWORK = argv.network || "devnet";
 process.env.FEE_TOKEN = argv.fee || "eth";


### PR DESCRIPTION
# Task name here

Fixes #326 

## Types of change

- [ ] Feature
- [ ] Bug
- [X] Enhancement

## Comments (optional)

Have not cleaned up yet, but tested with bulletproof contracts, should work with previous data types
