### PR TITLE
add a new chain type only for forked mainnet

### DIFF
--- a/packages/nextjs/hooks/useConditionalStarkProfile.tsx
+++ b/packages/nextjs/hooks/useConditionalStarkProfile.tsx
@@ -2,13 +2,16 @@ import { useStarkProfile } from "@starknet-react/core";
 import * as chains from "@starknet-react/chains";
 import scaffoldConfig from "~~/scaffold.config";
 
+const shouldUseProfile = () => {
+  const set = new Set(["mainnet", "sepolia"]);
+  return set.has(scaffoldConfig.targetNetworks[0].network) && scaffoldConfig.targetNetworks[0].id !== chains.devnet.id;
+}
+
 const useConditionalStarkProfile = (address: chains.Address | undefined) => {
-  const shouldUseProfile =
-    scaffoldConfig.targetNetworks[0].id !== chains.devnet.id;
   // Conditional hooks are not recommended, but in this case, it's the best approach to avoid issues on devnet.
-  const profile = shouldUseProfile
+  const profile = shouldUseProfile()
     ? // eslint-disable-next-line react-hooks/rules-of-hooks
-      useStarkProfile({ address })
+    useStarkProfile({ address })
     : { data: undefined };
   return profile;
 };

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -9,6 +9,27 @@ export type ScaffoldConfig = {
   autoConnectTTL: number;
 };
 
+const forkMainnet = {
+  id: BigInt("0x534e5f4d41494e"),
+  network: "devnet",
+  name: "Starknet Devnet",
+  nativeCurrency: {
+    address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+    name: "Ether",
+    symbol: "ETH",
+    decimals: 18
+  },
+  testnet: true,
+  rpcUrls: {
+    default: {
+      http: []
+    },
+    public: {
+      http: ["http://localhost:5050/rpc"]
+    }
+  }
+} as chains.Chain;
+
 const scaffoldConfig = {
   targetNetworks: [chains.devnet],
   // Only show the Burner Wallet when running on devnet

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -1,34 +1,14 @@
-import * as chains from "@starknet-react/chains";
+import { Chain } from "@starknet-react/chains";
+import { supportedChains as chains } from "./supportedChains";
 
 export type ScaffoldConfig = {
-  targetNetworks: readonly chains.Chain[];
+  targetNetworks: readonly Chain[];
   pollingInterval: number;
   onlyLocalBurnerWallet: boolean;
   rpcProviderUrl: string;
   walletAutoConnect: boolean;
   autoConnectTTL: number;
 };
-
-const forkMainnet = {
-  id: BigInt("0x534e5f4d41494e"),
-  network: "devnet",
-  name: "Starknet Devnet",
-  nativeCurrency: {
-    address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-    name: "Ether",
-    symbol: "ETH",
-    decimals: 18
-  },
-  testnet: true,
-  rpcUrls: {
-    default: {
-      http: []
-    },
-    public: {
-      http: ["http://localhost:5050/rpc"]
-    }
-  }
-} as chains.Chain;
 
 const scaffoldConfig = {
   targetNetworks: [chains.devnet],

--- a/packages/nextjs/supportedChains.ts
+++ b/packages/nextjs/supportedChains.ts
@@ -1,0 +1,24 @@
+import * as chains from "@starknet-react/chains";
+
+const mainnetFork = {
+  id: BigInt("0x534e5f4d41494e"),
+  network: "devnet",
+  name: "Starknet Devnet",
+  nativeCurrency: {
+    address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+    name: "Ether",
+    symbol: "ETH",
+    decimals: 18
+  },
+  testnet: true,
+  rpcUrls: {
+    default: {
+      http: []
+    },
+    public: {
+      http: ["http://localhost:5050/rpc"]
+    }
+  }
+} as chains.Chain;
+
+export const supportedChains = { ...chains, mainnetFork };


### PR DESCRIPTION
# Add a new chain option `forkMainnet` for `scaffoldConfig`

Fixes #313 

## Types of change

- [ ] Feature
- [ ] Bug
- [x] Enhancement

## Comments

If developer start the local testnet from a mainnet fork chain, something like `starknet-devnet --fork-network https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_7/PLACE_HOLDER --seed 0 --account-class cairo1`, then can change `targetNetworks` to `[forkMainnet]`
