### PR TITLE
fix: enum need default value if stored as storage

### DIFF
--- a/packages/snfoundry/contracts/src/arrays_spans.cairo
+++ b/packages/snfoundry/contracts/src/arrays_spans.cairo
@@ -2,6 +2,7 @@ use starknet::ContractAddress;
 
 #[derive(Drop, Serde, starknet::Store)]
 enum SampleEnum {
+    #[default]
     enum1: u256,
     enum2: u256,
     enum3: ByteArray,

--- a/packages/snfoundry/contracts/src/complex.cairo
+++ b/packages/snfoundry/contracts/src/complex.cairo
@@ -2,6 +2,7 @@ use starknet::ContractAddress;
 
 #[derive(Drop, Serde, starknet::Store)]
 enum SampleEnum {
+    #[default]
     enum1: u256,
     enum2: u256,
     enum3: ByteArray,

--- a/packages/snfoundry/contracts/src/structs.cairo
+++ b/packages/snfoundry/contracts/src/structs.cairo
@@ -2,6 +2,7 @@ use starknet::ContractAddress;
 
 #[derive(Drop, Serde, starknet::Store)]
 enum SampleEnum {
+    #[default]
     enum1: u256,
     enum2: u256,
     enum3: ByteArray,


### PR DESCRIPTION
# Enum as storage need a default attribute otherwise front end not able to read for default value

## Types of change

- [ ] Feature
- [X] Bug
- [ ] Enhancement