### PR TITLE
fix : handle edge case for deployed contracts

### DIFF
--- a/packages/snfoundry/scripts-ts/deploy-contract.ts
+++ b/packages/snfoundry/scripts-ts/deploy-contract.ts
@@ -121,7 +121,10 @@ const findContractFile = (
   const matchingFile = files.find((file) => pattern.test(file));
 
   if (!matchingFile) {
-    throw new Error(`Could not find ${fileType} file for contract ${contract}`);
+    throw new Error(
+      `Could not find ${fileType} file for contract "${contract}". ` +
+        `Try removing snfoundry/contracts/target, then run 'yarn compile' and check if your contract name is correct inside the contracts/target/dev directory.`
+    );
   }
 
   return path.join(targetDir, matchingFile);


### PR DESCRIPTION
# Improve contract file finding on deploy script

I realized sometimes there will be this pattern:
`../contracts/target/dev/contracts_contracts_${contract}_${contract}.compiled_contract_class.json`

and not:

`../contracts/target/dev/contracts_${contract}.compiled_contract_class.json`

this finding solution works in a better way by finding the file matching it with its tail. 

## Types of change

- [ ] Feature
- [ ] Bug
- [x] Enhancement

## Comments (optional)
