### PR TITLE
feat: add unit test for types.ts

### DIFF
--- a/packages/nextjs/utils/scaffold-stark/__test__/types.test.ts
+++ b/packages/nextjs/utils/scaffold-stark/__test__/types.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 import {
   isCairoInt,
   isCairoBigInt,
@@ -20,177 +20,190 @@ import {
   isCairoOption,
   isCairoResult,
   parseGenericType,
-} from '../../../utils/scaffold-stark/types';
+} from "../../../utils/scaffold-stark/types";
 
-describe('Cairo Type Checks', () => {
-  describe('isCairoInt', () => {
-    it('should return true for valid Cairo integer types', () => {
-      expect(isCairoInt('core::integer::u8')).toBe(true);
-      expect(isCairoInt('core::integer::u16')).toBe(true);
-      expect(isCairoInt('core::integer::u32')).toBe(true);
-      expect(isCairoInt('core::integer::i8')).toBe(true);
-      expect(isCairoInt('core::integer::i16')).toBe(true);
-      expect(isCairoInt('core::integer::i32')).toBe(true);
+describe("Cairo Type Checks", () => {
+  describe("isCairoInt", () => {
+    it("should return true for valid Cairo integer types", () => {
+      expect(isCairoInt("core::integer::u8")).toBe(true);
+      expect(isCairoInt("core::integer::u16")).toBe(true);
+      expect(isCairoInt("core::integer::u32")).toBe(true);
+      expect(isCairoInt("core::integer::i8")).toBe(true);
+      expect(isCairoInt("core::integer::i16")).toBe(true);
+      expect(isCairoInt("core::integer::i32")).toBe(true);
     });
 
-    it('should return false for invalid Cairo integer types', () => {
-      expect(isCairoInt('core::integer::u64')).toBe(false);
-      expect(isCairoInt('core::integer::u256')).toBe(false);
-      expect(isCairoInt('core::felt252')).toBe(false);
-      expect(isCairoInt('')).toBe(false);
-    });
-  });
-
-  describe('isCairoBigInt', () => {
-    it('should return true for valid Cairo big integer types', () => {
-      expect(isCairoBigInt('core::integer::u64')).toBe(true);
-      expect(isCairoBigInt('core::integer::u128')).toBe(true);
-      expect(isCairoBigInt('core::integer::i64')).toBe(true);
-      expect(isCairoBigInt('core::integer::i128')).toBe(true);
-    });
-
-    it('should return false for invalid Cairo big integer types', () => {
-      expect(isCairoBigInt('core::integer::u32')).toBe(false);
-      expect(isCairoBigInt('core::integer::u256')).toBe(false);
-      expect(isCairoBigInt('')).toBe(false);
+    it("should return false for invalid Cairo integer types", () => {
+      expect(isCairoInt("core::integer::u64")).toBe(false);
+      expect(isCairoInt("core::integer::u256")).toBe(false);
+      expect(isCairoInt("core::felt252")).toBe(false);
+      expect(isCairoInt("")).toBe(false);
     });
   });
 
-  describe('isCairoU256', () => {
-    it('should return true for Cairo u256 type', () => {
-      expect(isCairoU256('core::integer::u256')).toBe(true);
+  describe("isCairoBigInt", () => {
+    it("should return true for valid Cairo big integer types", () => {
+      expect(isCairoBigInt("core::integer::u64")).toBe(true);
+      expect(isCairoBigInt("core::integer::u128")).toBe(true);
+      expect(isCairoBigInt("core::integer::i64")).toBe(true);
+      expect(isCairoBigInt("core::integer::i128")).toBe(true);
     });
 
-    it('should return false for non-u256 types', () => {
-      expect(isCairoU256('core::integer::u128')).toBe(false);
-      expect(isCairoU256('')).toBe(false);
-    });
-  });
-
-  describe('isCairoContractAddress', () => {
-    it('should return true for Cairo contract address type', () => {
-      expect(isCairoContractAddress('core::starknet::contract_address::ContractAddress')).toBe(true);
-    });
-
-    it('should return false for non-contract address types', () => {
-      expect(isCairoContractAddress('core::starknet::eth_address::EthAddress')).toBe(false);
-      expect(isCairoContractAddress('')).toBe(false);
+    it("should return false for invalid Cairo big integer types", () => {
+      expect(isCairoBigInt("core::integer::u32")).toBe(false);
+      expect(isCairoBigInt("core::integer::u256")).toBe(false);
+      expect(isCairoBigInt("")).toBe(false);
     });
   });
 
-  describe('isCairoFelt', () => {
-    it('should return true for Cairo felt252 type', () => {
-      expect(isCairoFelt('core::felt252')).toBe(true);
+  describe("isCairoU256", () => {
+    it("should return true for Cairo u256 type", () => {
+      expect(isCairoU256("core::integer::u256")).toBe(true);
     });
 
-    it('should return false for non-felt types', () => {
-      expect(isCairoFelt('core::integer::u256')).toBe(false);
-      expect(isCairoFelt('')).toBe(false);
-    });
-  });
-
-  describe('isCairoTuple', () => {
-    it('should return true for Cairo tuple types', () => {
-      expect(isCairoTuple('(core::felt252, core::integer::u256)')).toBe(true);
-      expect(isCairoTuple('(core::felt252)')).toBe(true);
-    });
-
-    it('should return false for empty tuple and non-tuple types', () => {
-      expect(isCairoTuple('()')).toBe(false);
-      expect(isCairoTuple('core::felt252')).toBe(false);
-      expect(isCairoTuple('')).toBe(false);
+    it("should return false for non-u256 types", () => {
+      expect(isCairoU256("core::integer::u128")).toBe(false);
+      expect(isCairoU256("")).toBe(false);
     });
   });
 
-  describe('isStructOrEnum', () => {
-    it('should return true for struct types', () => {
-      expect(isStructOrEnum({ type: 'struct' })).toBe(true);
+  describe("isCairoContractAddress", () => {
+    it("should return true for Cairo contract address type", () => {
+      expect(
+        isCairoContractAddress(
+          "core::starknet::contract_address::ContractAddress",
+        ),
+      ).toBe(true);
     });
 
-    it('should return true for enum types', () => {
-      expect(isStructOrEnum({ type: 'enum' })).toBe(true);
+    it("should return false for non-contract address types", () => {
+      expect(
+        isCairoContractAddress("core::starknet::eth_address::EthAddress"),
+      ).toBe(false);
+      expect(isCairoContractAddress("")).toBe(false);
+    });
+  });
+
+  describe("isCairoFelt", () => {
+    it("should return true for Cairo felt252 type", () => {
+      expect(isCairoFelt("core::felt252")).toBe(true);
     });
 
-    it('should return false for other types', () => {
-      expect(isStructOrEnum({ type: 'other' })).toBe(false);
+    it("should return false for non-felt types", () => {
+      expect(isCairoFelt("core::integer::u256")).toBe(false);
+      expect(isCairoFelt("")).toBe(false);
+    });
+  });
+
+  describe("isCairoTuple", () => {
+    it("should return true for Cairo tuple types", () => {
+      expect(isCairoTuple("(core::felt252, core::integer::u256)")).toBe(true);
+      expect(isCairoTuple("(core::felt252)")).toBe(true);
+    });
+
+    it("should return false for empty tuple and non-tuple types", () => {
+      expect(isCairoTuple("()")).toBe(false);
+      expect(isCairoTuple("core::felt252")).toBe(false);
+      expect(isCairoTuple("")).toBe(false);
+    });
+  });
+
+  describe("isStructOrEnum", () => {
+    it("should return true for struct types", () => {
+      expect(isStructOrEnum({ type: "struct" })).toBe(true);
+    });
+
+    it("should return true for enum types", () => {
+      expect(isStructOrEnum({ type: "enum" })).toBe(true);
+    });
+
+    it("should return false for other types", () => {
+      expect(isStructOrEnum({ type: "other" })).toBe(false);
       expect(isStructOrEnum({})).toBe(false);
     });
   });
 
-  describe('Collection Types', () => {
-    it('should identify Cairo array types', () => {
-      expect(isCairoArray('core::array<felt252>')).toBe(true);
-      expect(isCairoArray('other::type')).toBe(false);
+  describe("Collection Types", () => {
+    it("should identify Cairo array types", () => {
+      expect(isCairoArray("core::array<felt252>")).toBe(true);
+      expect(isCairoArray("other::type")).toBe(false);
     });
 
-    it('should identify Cairo option types', () => {
-      expect(isCairoOption('core::option<felt252>')).toBe(true);
-      expect(isCairoOption('other::type')).toBe(false);
+    it("should identify Cairo option types", () => {
+      expect(isCairoOption("core::option<felt252>")).toBe(true);
+      expect(isCairoOption("other::type")).toBe(false);
     });
 
-    it('should identify Cairo result types', () => {
-      expect(isCairoResult('core::result<felt252>')).toBe(true);
-      expect(isCairoResult('other::type')).toBe(false);
-    });
-  });
-
-  describe('parseGenericType', () => {
-    it('should parse simple generic types', () => {
-      expect(parseGenericType('Option<felt252>')).toEqual(['felt252']);
-    });
-
-    it('should parse tuple types within generics', () => {
-      expect(parseGenericType('Option<(felt252, u256)>')).toEqual('(felt252, u256)');
-    });
-
-    it('should parse multiple type parameters', () => {
-      expect(parseGenericType('Result<felt252, u256>')).toEqual(['felt252', 'u256']);
-    });
-
-    it('should handle nested generic types', () => {
-      expect(parseGenericType('Option<Array<felt252>>')).toEqual(['Array<felt252']);
-      expect(parseGenericType('Array<felt252>')).toEqual(['felt252']);
-    });
-
-    it('should return original string if no generic parameters', () => {
-      expect(parseGenericType('felt252')).toBe('felt252');
+    it("should identify Cairo result types", () => {
+      expect(isCairoResult("core::result<felt252>")).toBe(true);
+      expect(isCairoResult("other::type")).toBe(false);
     });
   });
 
-  describe('isCairoType', () => {
-    it('should return true for all valid Cairo types', () => {
+  describe("parseGenericType", () => {
+    it("should parse simple generic types", () => {
+      expect(parseGenericType("Option<felt252>")).toEqual(["felt252"]);
+    });
+
+    it("should parse tuple types within generics", () => {
+      expect(parseGenericType("Option<(felt252, u256)>")).toEqual(
+        "(felt252, u256)",
+      );
+    });
+
+    it("should parse multiple type parameters", () => {
+      expect(parseGenericType("Result<felt252, u256>")).toEqual([
+        "felt252",
+        "u256",
+      ]);
+    });
+
+    it("should handle nested generic types", () => {
+      expect(parseGenericType("Option<Array<felt252>>")).toEqual([
+        "Array<felt252",
+      ]);
+      expect(parseGenericType("Array<felt252>")).toEqual(["felt252"]);
+    });
+
+    it("should return original string if no generic parameters", () => {
+      expect(parseGenericType("felt252")).toBe("felt252");
+    });
+  });
+
+  describe("isCairoType", () => {
+    it("should return true for all valid Cairo types", () => {
       const validTypes = [
-        'core::integer::u8',
-        'core::integer::u64',
-        'core::integer::u256',
-        'core::starknet::contract_address::ContractAddress',
-        'core::starknet::eth_address::EthAddress',
-        'core::starknet::class_hash::ClassHash',
-        'function',
-        '()',
-        'core::bool',
-        'core::bytes_31::bytes31',
-        'core::byte_array::ByteArray',
-        'core::starknet::secp256k1::Secp256k1Point',
-        'core::felt252',
-        '(core::felt252, core::integer::u256)',
+        "core::integer::u8",
+        "core::integer::u64",
+        "core::integer::u256",
+        "core::starknet::contract_address::ContractAddress",
+        "core::starknet::eth_address::EthAddress",
+        "core::starknet::class_hash::ClassHash",
+        "function",
+        "()",
+        "core::bool",
+        "core::bytes_31::bytes31",
+        "core::byte_array::ByteArray",
+        "core::starknet::secp256k1::Secp256k1Point",
+        "core::felt252",
+        "(core::felt252, core::integer::u256)",
       ];
 
-      validTypes.forEach(type => {
+      validTypes.forEach((type) => {
         expect(isCairoType(type)).toBe(true);
       });
     });
 
-    it('should return false for invalid Cairo types', () => {
+    it("should return false for invalid Cairo types", () => {
       const invalidTypes = [
-        '',
-        'invalid_type',
-        'core::unknown',
-        'string',
-        'number',
+        "",
+        "invalid_type",
+        "core::unknown",
+        "string",
+        "number",
       ];
 
-      invalidTypes.forEach(type => {
+      invalidTypes.forEach((type) => {
         expect(isCairoType(type)).toBe(false);
       });
     });

--- a/packages/nextjs/utils/scaffold-stark/__test__/types.test.ts
+++ b/packages/nextjs/utils/scaffold-stark/__test__/types.test.ts
@@ -21,6 +21,7 @@ import {
   isCairoResult,
   parseGenericType,
 } from "../../../utils/scaffold-stark/types";
+import { AbiParameter } from "../contract";
 
 describe("Cairo Type Checks", () => {
   describe("isCairoInt", () => {
@@ -110,11 +111,23 @@ describe("Cairo Type Checks", () => {
 
   describe("isStructOrEnum", () => {
     it("should return true for struct types", () => {
-      expect(isStructOrEnum({ type: "struct" })).toBe(true);
+      expect(
+        isStructOrEnum({
+          type: "struct",
+          name: "MyStruct",
+          members: [] as readonly AbiParameter[]
+        })
+      ).toBe(true);
     });
-
+    
     it("should return true for enum types", () => {
-      expect(isStructOrEnum({ type: "enum" })).toBe(true);
+      expect(
+        isStructOrEnum({
+          type: "enum",
+          name: "MyEnum",
+          members: [] as readonly AbiParameter[]
+        })
+      ).toBe(true);
     });
 
     it("should return false for other types", () => {

--- a/packages/nextjs/utils/scaffold-stark/__test__/types.test.ts
+++ b/packages/nextjs/utils/scaffold-stark/__test__/types.test.ts
@@ -115,18 +115,18 @@ describe("Cairo Type Checks", () => {
         isStructOrEnum({
           type: "struct",
           name: "MyStruct",
-          members: [] as readonly AbiParameter[]
-        })
+          members: [] as readonly AbiParameter[],
+        }),
       ).toBe(true);
     });
-    
+
     it("should return true for enum types", () => {
       expect(
         isStructOrEnum({
           type: "enum",
           name: "MyEnum",
-          members: [] as readonly AbiParameter[]
-        })
+          members: [] as readonly AbiParameter[],
+        }),
       ).toBe(true);
     });
 

--- a/packages/nextjs/utils/scaffold-stark/__test__/types.test.ts
+++ b/packages/nextjs/utils/scaffold-stark/__test__/types.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isCairoInt,
+  isCairoBigInt,
+  isCairoU256,
+  isCairoContractAddress,
+  isCairoEthAddress,
+  isCairoClassHash,
+  isCairoFunction,
+  isCairoVoid,
+  isCairoBool,
+  isCairoBytes31,
+  isCairoByteArray,
+  isCairoSecp256k1Point,
+  isCairoFelt,
+  isCairoTuple,
+  isCairoType,
+  isStructOrEnum,
+  isCairoArray,
+  isCairoOption,
+  isCairoResult,
+  parseGenericType,
+} from '../../../utils/scaffold-stark/types';
+
+describe('Cairo Type Checks', () => {
+  describe('isCairoInt', () => {
+    it('should return true for valid Cairo integer types', () => {
+      expect(isCairoInt('core::integer::u8')).toBe(true);
+      expect(isCairoInt('core::integer::u16')).toBe(true);
+      expect(isCairoInt('core::integer::u32')).toBe(true);
+      expect(isCairoInt('core::integer::i8')).toBe(true);
+      expect(isCairoInt('core::integer::i16')).toBe(true);
+      expect(isCairoInt('core::integer::i32')).toBe(true);
+    });
+
+    it('should return false for invalid Cairo integer types', () => {
+      expect(isCairoInt('core::integer::u64')).toBe(false);
+      expect(isCairoInt('core::integer::u256')).toBe(false);
+      expect(isCairoInt('core::felt252')).toBe(false);
+      expect(isCairoInt('')).toBe(false);
+    });
+  });
+
+  describe('isCairoBigInt', () => {
+    it('should return true for valid Cairo big integer types', () => {
+      expect(isCairoBigInt('core::integer::u64')).toBe(true);
+      expect(isCairoBigInt('core::integer::u128')).toBe(true);
+      expect(isCairoBigInt('core::integer::i64')).toBe(true);
+      expect(isCairoBigInt('core::integer::i128')).toBe(true);
+    });
+
+    it('should return false for invalid Cairo big integer types', () => {
+      expect(isCairoBigInt('core::integer::u32')).toBe(false);
+      expect(isCairoBigInt('core::integer::u256')).toBe(false);
+      expect(isCairoBigInt('')).toBe(false);
+    });
+  });
+
+  describe('isCairoU256', () => {
+    it('should return true for Cairo u256 type', () => {
+      expect(isCairoU256('core::integer::u256')).toBe(true);
+    });
+
+    it('should return false for non-u256 types', () => {
+      expect(isCairoU256('core::integer::u128')).toBe(false);
+      expect(isCairoU256('')).toBe(false);
+    });
+  });
+
+  describe('isCairoContractAddress', () => {
+    it('should return true for Cairo contract address type', () => {
+      expect(isCairoContractAddress('core::starknet::contract_address::ContractAddress')).toBe(true);
+    });
+
+    it('should return false for non-contract address types', () => {
+      expect(isCairoContractAddress('core::starknet::eth_address::EthAddress')).toBe(false);
+      expect(isCairoContractAddress('')).toBe(false);
+    });
+  });
+
+  describe('isCairoFelt', () => {
+    it('should return true for Cairo felt252 type', () => {
+      expect(isCairoFelt('core::felt252')).toBe(true);
+    });
+
+    it('should return false for non-felt types', () => {
+      expect(isCairoFelt('core::integer::u256')).toBe(false);
+      expect(isCairoFelt('')).toBe(false);
+    });
+  });
+
+  describe('isCairoTuple', () => {
+    it('should return true for Cairo tuple types', () => {
+      expect(isCairoTuple('(core::felt252, core::integer::u256)')).toBe(true);
+      expect(isCairoTuple('(core::felt252)')).toBe(true);
+    });
+
+    it('should return false for empty tuple and non-tuple types', () => {
+      expect(isCairoTuple('()')).toBe(false);
+      expect(isCairoTuple('core::felt252')).toBe(false);
+      expect(isCairoTuple('')).toBe(false);
+    });
+  });
+
+  describe('isStructOrEnum', () => {
+    it('should return true for struct types', () => {
+      expect(isStructOrEnum({ type: 'struct' })).toBe(true);
+    });
+
+    it('should return true for enum types', () => {
+      expect(isStructOrEnum({ type: 'enum' })).toBe(true);
+    });
+
+    it('should return false for other types', () => {
+      expect(isStructOrEnum({ type: 'other' })).toBe(false);
+      expect(isStructOrEnum({})).toBe(false);
+    });
+  });
+
+  describe('Collection Types', () => {
+    it('should identify Cairo array types', () => {
+      expect(isCairoArray('core::array<felt252>')).toBe(true);
+      expect(isCairoArray('other::type')).toBe(false);
+    });
+
+    it('should identify Cairo option types', () => {
+      expect(isCairoOption('core::option<felt252>')).toBe(true);
+      expect(isCairoOption('other::type')).toBe(false);
+    });
+
+    it('should identify Cairo result types', () => {
+      expect(isCairoResult('core::result<felt252>')).toBe(true);
+      expect(isCairoResult('other::type')).toBe(false);
+    });
+  });
+
+  describe('parseGenericType', () => {
+    it('should parse simple generic types', () => {
+      expect(parseGenericType('Option<felt252>')).toEqual(['felt252']);
+    });
+
+    it('should parse tuple types within generics', () => {
+      expect(parseGenericType('Option<(felt252, u256)>')).toEqual('(felt252, u256)');
+    });
+
+    it('should parse multiple type parameters', () => {
+      expect(parseGenericType('Result<felt252, u256>')).toEqual(['felt252', 'u256']);
+    });
+
+    it('should handle nested generic types', () => {
+      expect(parseGenericType('Option<Array<felt252>>')).toEqual(['Array<felt252']);
+      expect(parseGenericType('Array<felt252>')).toEqual(['felt252']);
+    });
+
+    it('should return original string if no generic parameters', () => {
+      expect(parseGenericType('felt252')).toBe('felt252');
+    });
+  });
+
+  describe('isCairoType', () => {
+    it('should return true for all valid Cairo types', () => {
+      const validTypes = [
+        'core::integer::u8',
+        'core::integer::u64',
+        'core::integer::u256',
+        'core::starknet::contract_address::ContractAddress',
+        'core::starknet::eth_address::EthAddress',
+        'core::starknet::class_hash::ClassHash',
+        'function',
+        '()',
+        'core::bool',
+        'core::bytes_31::bytes31',
+        'core::byte_array::ByteArray',
+        'core::starknet::secp256k1::Secp256k1Point',
+        'core::felt252',
+        '(core::felt252, core::integer::u256)',
+      ];
+
+      validTypes.forEach(type => {
+        expect(isCairoType(type)).toBe(true);
+      });
+    });
+
+    it('should return false for invalid Cairo types', () => {
+      const invalidTypes = [
+        '',
+        'invalid_type',
+        'core::unknown',
+        'string',
+        'number',
+      ];
+
+      invalidTypes.forEach(type => {
+        expect(isCairoType(type)).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Unit test for types.ts

- Fixes #371

## Types of change

- [ ] Feature
- [ ] Bug
- [X] Enhancement

## Comments 

Added comprehensive unit tests for utils/scaffold-stark/types.ts file with:

### Unit tests for all type checking functions

- [x] Cairo integer types (u8, u16, u32, etc.)
- [X] Cairo big integer types (u64, u128)
- [X] Special types (U256, ContractAddress, EthAddress, etc.)
- [X] Tuple types
- [X] Struct and enum type checks
- [X] Collection types (Array, Option, Result)
- [X] Generic type parsing


### Test coverage includes

- [X] Positive cases (valid type checks)
- [X] Negative cases (invalid types)
- [X] Edge cases and type variants

### Test execution and coverage

<img width="745" alt="Screenshot 2024-12-17 at 8 49 16 AM" src="https://github.com/user-attachments/assets/fcdd609e-1695-4aa5-bac3-7e6a392a39d4" />


<img width="745" alt="Screenshot 2024-12-17 at 8 49 58 AM" src="https://github.com/user-attachments/assets/2e51150c-2595-4bda-899a-de0f4529c7d2" />
