### PR TITLE
chore: remove `isFork` flag from `scaffold.config.ts`

### DIFF
--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/index.tsx
@@ -45,8 +45,8 @@ export const CustomConnectButton = () => {
   }, [account]);
 
   if (status === "disconnected") return <ConnectModal />;
-  // Skip wrong network check if using a fork
-  if (!scaffoldConfig.isFork && accountChainId !== targetNetwork.id) {
+
+  if (accountChainId !== targetNetwork.id) {
     return <WrongNetworkDropdown />;
   }
 

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -8,12 +8,6 @@ export type ScaffoldConfig = {
   rpcProviderUrl: string;
   walletAutoConnect: boolean;
   autoConnectTTL: number;
-  /**
-   * Flag to indicate if the network is a fork of another network
-   * This is used to handle network validation differently for forked networks
-   * since they share the same chain ID as their parent network
-   */
-  isFork?: boolean;
 };
 
 const scaffoldConfig = {
@@ -31,12 +25,6 @@ const scaffoldConfig = {
    */
   autoConnectTTL: 60000,
   walletAutoConnect: true,
-  /**
-   * Set to true when using a fork of a network
-   * This will prevent showing the wrong network dropdown when the chainId matches
-   * but the RPC URL is different (e.g., when using a local fork of mainnet)
-   */
-  isFork: false,
 } as const satisfies ScaffoldConfig;
 
 export default scaffoldConfig;

--- a/packages/nextjs/supportedChains.ts
+++ b/packages/nextjs/supportedChains.ts
@@ -1,5 +1,6 @@
 import * as chains from "@starknet-react/chains";
 
+// devnet with mainnet network ID
 const mainnetFork = {
   id: BigInt("0x534e5f4d41494e"),
   network: "devnet",


### PR DESCRIPTION
# Task name here

Removes `isFork` flag due to redundancy with definition of `mainnetFork`

## Types of change

- [ ] Feature
- [ ] Bug
- [X] Enhancement

## Comments (optional)
