### PR TITLE
fix: devnet matches sepolia

### DIFF
--- a/packages/nextjs/services/web3/provider.ts
+++ b/packages/nextjs/services/web3/provider.ts
@@ -7,7 +7,7 @@ import {
 import * as chains from "@starknet-react/chains";
 
 const containsDevnet = (networks: readonly chains.Chain[]) => {
-  return networks.filter((it) => it.id == chains.devnet.id).length > 0;
+  return networks.filter((it) => it.network == chains.devnet.network).length > 0;
 };
 
 const provider =

--- a/packages/nextjs/services/web3/provider.ts
+++ b/packages/nextjs/services/web3/provider.ts
@@ -7,7 +7,9 @@ import {
 import * as chains from "@starknet-react/chains";
 
 const containsDevnet = (networks: readonly chains.Chain[]) => {
-  return networks.filter((it) => it.network == chains.devnet.network).length > 0;
+  return (
+    networks.filter((it) => it.network == chains.devnet.network).length > 0
+  );
 };
 
 const provider =


### PR DESCRIPTION
# Fix: RPC Provider Selection for Sepolia/Devnet

Fixes #relevant-issue-here

## Types of change
- [x] Bug

## Description

Modified RPC provider selection logic due to Sepolia testnet and devnet sharing the same chain ID `0x534e5f5345504f4c4941`. Previously, this caused the provider to incorrectly fallback to public endpoints even when custom RPC was configured.

Changed `containsDevnet` check to properly handle network identification:
```diff
- return networks.filter((it) => it.id == chains.devnet.id).length > 0;
+ return networks.filter((it) => it.network == chains.devnet.network).length > 0;
