### PR TITLE
Event key filter

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
@@ -21,6 +21,7 @@ import { events as starknetEvents, CallData } from "starknet";
 import { parseEventData } from "~~/utils/scaffold-stark/eventsData";
 import { composeEventFilterKeys } from "~~/utils/scaffold-stark/eventKeyFilter";
 
+const MAX_KEYS_COUNT = 16;
 /**
  * Reads events from a deployed contract
  * @param config - The config settings
@@ -104,6 +105,7 @@ export const useScaffoldEventHistory = <
             composeEventFilterKeys(filters, event, deployedContractData.abi)
           );
         }
+        keys = keys.slice(0, MAX_KEYS_COUNT);
         const rawEventResp = await publicClient.getEvents({
           chunk_size: 100,
           keys,

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
@@ -87,7 +87,7 @@ export const useScaffoldEventHistory = <
       }
 
       const event = (deployedContractData.abi as Abi).find(
-        (part) => part.type === "event" && part.name === eventName
+        (part) => part.type === "event" && part.name === eventName,
       ) as ExtractAbiEvent<ContractAbi<TContractName>, TEventName>;
 
       const blockNumber = (await publicClient.getBlockLatestAccepted())
@@ -102,7 +102,7 @@ export const useScaffoldEventHistory = <
         ];
         if (filters) {
           keys = keys.concat(
-            composeEventFilterKeys(filters, event, deployedContractData.abi)
+            composeEventFilterKeys(filters, event, deployedContractData.abi),
           );
         }
         keys = keys.slice(0, MAX_KEYS_COUNT);
@@ -131,13 +131,13 @@ export const useScaffoldEventHistory = <
             transaction:
               transactionData && logs[i].transaction_hash !== null
                 ? await publicClient.getTransactionByHash(
-                    logs[i].transaction_hash
+                    logs[i].transaction_hash,
                   )
                 : null,
             receipt:
               receiptData && logs[i].transaction_hash !== null
                 ? await publicClient.getTransactionReceipt(
-                    logs[i].transaction_hash
+                    logs[i].transaction_hash,
                   )
                 : null,
           });
@@ -199,7 +199,7 @@ export const useScaffoldEventHistory = <
       ? targetNetwork.id !== devnet.id
         ? scaffoldConfig.pollingInterval
         : 4_000
-      : null
+      : null,
   );
 
   const eventHistoryData = useMemo(() => {
@@ -210,7 +210,7 @@ export const useScaffoldEventHistory = <
           logs,
           starknetEvents.getAbiEvents(deployedContractData.abi),
           CallData.getAbiStruct(deployedContractData.abi),
-          CallData.getAbiEnum(deployedContractData.abi)
+          CallData.getAbiEnum(deployedContractData.abi),
         );
         const args = parsed.length ? parsed[0][eventName] : {};
         const { event: rawEvent, ...rest } = event;

--- a/packages/nextjs/utils/scaffold-stark/__test__/eventKeyFilter.test.ts
+++ b/packages/nextjs/utils/scaffold-stark/__test__/eventKeyFilter.test.ts
@@ -347,4 +347,106 @@ describe("composeEventFilterKeys", () => {
       ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
     ]);
   });
+
+  it("should compose event filter keys with multiple matching keys correctly", () => {
+    expect(
+      composeEventFilterKeys(
+        {
+          greeting_setter: [
+            "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+            "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+            "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b4",
+          ],
+          new_greeting: "hello world",
+          event_type: [9987n, 9988n, 9989n],
+          addresses: [
+            [
+              "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+              "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+            ],
+            [
+              "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+              "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+            ],
+            [
+              "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b4",
+              "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115695",
+            ],
+          ],
+        },
+        event as any,
+        mockDeployedContractAbi.abi,
+      ),
+    ).toEqual([
+      [
+        "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+        "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+        "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b4",
+      ],
+      ["0x0"],
+      ["0x68656c6c6f20776f726c64"],
+      ["0xb"],
+      ["0x2703", "0x2704", "0x2705"],
+      ["0x0", "0x0", "0x0"],
+      ["0x2", "0x2", "0x2"],
+      [
+        "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+        "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+        "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b4",
+      ],
+      [
+        "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+        "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+        "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115695",
+      ],
+    ]);
+  });
+
+  it("should compose event filter keys with multiple matching keys when 2d array is not uniform length", () => {
+    expect(
+      composeEventFilterKeys(
+        {
+          greeting_setter: [
+            "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+            "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+            "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b4",
+          ],
+          new_greeting: "hello world",
+          event_type: [9987n, 9988n, 9989n],
+          addresses: [
+            [
+              "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+              "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+            ],
+            [
+              "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+              "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+            ],
+            [
+              "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b4",
+            ],
+          ],
+          tup: {
+            0: 1n,
+            1: 2n,
+            2: true,
+            3: "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+          },
+        },
+        event as any,
+        mockDeployedContractAbi.abi,
+      ),
+    ).toEqual([
+      [
+        "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+        "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+        "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b4",
+      ],
+      ["0x0"],
+      ["0x68656c6c6f20776f726c64"],
+      ["0xb"],
+      ["0x2703", "0x2704", "0x2705"],
+      ["0x0", "0x0", "0x0"],
+    ]);
+  });
 });

--- a/packages/nextjs/utils/scaffold-stark/__test__/eventKeyFilter.test.ts
+++ b/packages/nextjs/utils/scaffold-stark/__test__/eventKeyFilter.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from "vitest";
+import { composeEventFilterKeys, serializeEventKey } from "../eventKeyFilter";
+import {
+  CairoCustomEnum,
+  CairoOption,
+  CairoOptionVariant,
+  CallData,
+} from "starknet";
+import { mockDeployedContractAbi } from "./mockDeployedContractAbi";
+
+const abiEnum = CallData.getAbiEnum(mockDeployedContractAbi.abi);
+const abiStruct = CallData.getAbiStruct(mockDeployedContractAbi.abi);
+const event = mockDeployedContractAbi.abi.find(
+  (part) =>
+    part.type === "event" &&
+    part.name === "contracts::YourContract::YourContract::GreetingChanged",
+);
+
+describe("serializeEventKey", () => {
+  it("should serialize event string key correctly", () => {
+    expect(
+      serializeEventKey(
+        "hello world",
+        { name: "", type: "core::byte_array::ByteArray" },
+        {},
+        {},
+      ),
+    ).toEqual(["0x0", "0x68656c6c6f20776f726c64", "0xb"]);
+  });
+
+  it("should serialize event long string event key correctly", () => {
+    expect(
+      serializeEventKey(
+        "Long string, more than 31 characters.",
+        { name: "", type: "core::byte_array::ByteArray" },
+        {},
+        {},
+      ),
+    ).toEqual([
+      "0x1",
+      "0x4c6f6e6720737472696e672c206d6f7265207468616e203331206368617261",
+      "0x63746572732e",
+      "0x6",
+    ]);
+  });
+
+  it("should serialize u256 event key correctly", () => {
+    expect(
+      serializeEventKey(
+        9986n,
+        { name: "", type: "core::integer::u256" },
+        abiStruct,
+        abiEnum,
+      ),
+    ).toEqual(["0x2702", "0x0"]);
+  });
+
+  it("should serialize u512 event key correctly", () => {
+    expect(
+      serializeEventKey(
+        9986n,
+        { name: "", type: "core::integer::u512" },
+        abiStruct,
+        abiEnum,
+      ),
+    ).toEqual(["0x2702", "0x0", "0x0", "0x0"]);
+  });
+
+  it("should serialize ContractAddress event key correctly", () => {
+    expect(
+      serializeEventKey(
+        "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+        { name: "", type: "core::starknet::contract_address::ContractAddress" },
+        abiStruct,
+        abiEnum,
+      ),
+    ).toEqual([
+      "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+    ]);
+  });
+
+  it("should serialize ContractAddress array event key correctly", () => {
+    expect(
+      serializeEventKey(
+        [
+          "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+          "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+        ],
+        {
+          name: "",
+          type: "core::array::Array::<core::starknet::contract_address::ContractAddress>",
+        },
+        abiStruct,
+        abiEnum,
+      ),
+    ).toEqual([
+      "0x2",
+      "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+      "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+    ]);
+  });
+
+  it("should serialize tuple event key correctly", () => {
+    expect(
+      serializeEventKey(
+        {
+          0: 1n,
+          1: 2n,
+          2: true,
+          3: "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+        },
+        {
+          name: "",
+          type: "(core::integer::u32, core::integer::u64, core::bool, core::starknet::contract_address::ContractAddress)",
+        },
+        abiStruct,
+        abiEnum,
+      ),
+    ).toEqual([
+      "0x1",
+      "0x2",
+      "0x1",
+      "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+    ]);
+  });
+
+  it("should serialize struct event key correctly", () => {
+    expect(
+      serializeEventKey(
+        {
+          addr: new CairoOption(
+            CairoOptionVariant.Some,
+            "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+          ),
+          val: new CairoOption(CairoOptionVariant.None),
+        },
+        {
+          name: "test",
+          type: "contracts::YourContract::SomeStruct",
+        },
+        abiStruct,
+        abiEnum,
+      ),
+    ).toEqual([
+      "0x0",
+      "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+      "0x1",
+    ]);
+  });
+
+  it("should handle simple enum variant", () => {
+    const simpleEnum = new CairoCustomEnum({
+      val1: "123",
+    });
+
+    const result = serializeEventKey(
+      simpleEnum,
+      { name: "enum_param", type: "contracts::YourContract::SimpleEnum" },
+      abiStruct,
+      abiEnum,
+    );
+
+    expect(result).toEqual(["0x0", "0x7b"]);
+  });
+
+  it("should serialize enum event key correctly", () => {
+    const simpleEnum = new CairoCustomEnum({
+      val1: 12,
+    });
+
+    const someEnum = new CairoCustomEnum({
+      val1: simpleEnum,
+    });
+    expect(
+      serializeEventKey(
+        someEnum,
+        {
+          name: "test",
+          type: "contracts::YourContract::SomeEnum",
+        },
+        abiStruct,
+        abiEnum,
+      ),
+    ).toEqual(["0x0", "0x0", "0xc"]);
+  });
+});
+
+describe("composeEventFilterKeys", () => {
+  it("should compose event filter keys correctly", () => {
+    expect(
+      composeEventFilterKeys(
+        {
+          new_greeting: "hello world",
+          event_type: 9987n,
+          addresses: [
+            "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+            "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+          ],
+          tup: {
+            0: 1n,
+            1: 2n,
+            2: true,
+            3: "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+          },
+          st: {
+            addr: new CairoOption(
+              CairoOptionVariant.Some,
+              "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+            ),
+            val: new CairoOption(CairoOptionVariant.None),
+          },
+          enum_val: new CairoCustomEnum({
+            val1: new CairoCustomEnum({
+              val1: 12,
+            }),
+          }),
+          bool_val: true,
+        },
+        event as any,
+        abiStruct,
+        abiEnum,
+      ),
+    ).toEqual([
+      "0x0",
+      "0x68656c6c6f20776f726c64",
+      "0xb",
+      "0x2703",
+      "0x0",
+      "0x2",
+      "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+      "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+      "0x1",
+      "0x2",
+      "0x1",
+      "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+      "0x0",
+      "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+      "0x1",
+      "0x0",
+      "0x0",
+      "0xc",
+      "0x1",
+    ]);
+  });
+});

--- a/packages/nextjs/utils/scaffold-stark/__test__/eventKeyFilter.test.ts
+++ b/packages/nextjs/utils/scaffold-stark/__test__/eventKeyFilter.test.ts
@@ -190,6 +190,8 @@ describe("composeEventFilterKeys", () => {
     expect(
       composeEventFilterKeys(
         {
+          greeting_setter:
+            "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
           new_greeting: "hello world",
           event_type: 9987n,
           addresses: [
@@ -217,29 +219,132 @@ describe("composeEventFilterKeys", () => {
           bool_val: true,
         },
         event as any,
-        abiStruct,
-        abiEnum,
+        mockDeployedContractAbi.abi,
       ),
     ).toEqual([
-      "0x0",
-      "0x68656c6c6f20776f726c64",
-      "0xb",
-      "0x2703",
-      "0x0",
-      "0x2",
-      "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
-      "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
-      "0x1",
-      "0x2",
-      "0x1",
-      "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
-      "0x0",
-      "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
-      "0x1",
-      "0x0",
-      "0x0",
-      "0xc",
-      "0x1",
+      ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
+      ["0x0"],
+      ["0x68656c6c6f20776f726c64"],
+      ["0xb"],
+      ["0x2703"],
+      ["0x0"],
+      ["0x2"],
+      ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
+      ["0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3"],
+      ["0x1"],
+      ["0x2"],
+      ["0x1"],
+      ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
+      ["0x0"],
+      ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
+      ["0x1"],
+      ["0x0"],
+      ["0x0"],
+      ["0xc"],
+      ["0x1"],
+    ]);
+  });
+
+  it("should compose event filter keys with any filter correctly", () => {
+    expect(
+      composeEventFilterKeys(
+        {
+          greeting_setter:
+            "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+          new_greeting: "hello world",
+          addresses: [
+            "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+            "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+          ],
+          tup: {
+            0: 1n,
+            1: 2n,
+            2: true,
+            3: "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+          },
+          st: {
+            addr: new CairoOption(
+              CairoOptionVariant.Some,
+              "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+            ),
+            val: new CairoOption(CairoOptionVariant.None),
+          },
+          enum_val: new CairoCustomEnum({
+            val1: new CairoCustomEnum({
+              val1: 12,
+            }),
+          }),
+          bool_val: true,
+        },
+        event as any,
+        mockDeployedContractAbi.abi,
+      ),
+    ).toEqual([
+      ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
+      ["0x0"],
+      ["0x68656c6c6f20776f726c64"],
+      ["0xb"],
+      [],
+      [],
+      ["0x2"],
+      ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
+      ["0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3"],
+      ["0x1"],
+      ["0x2"],
+      ["0x1"],
+      ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
+      ["0x0"],
+      ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
+      ["0x1"],
+      ["0x0"],
+      ["0x0"],
+      ["0xc"],
+      ["0x1"],
+    ]);
+  });
+
+  it("should compose event filter keys break when include any for uncertain length type", () => {
+    expect(
+      composeEventFilterKeys(
+        {
+          greeting_setter:
+            "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+          new_greeting: "hello world",
+          event_type: 9987n,
+          addresses: [
+            "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+            "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
+          ],
+          tup: {
+            0: 1n,
+            1: 2n,
+            2: true,
+            3: "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+          },
+          enum_val: new CairoCustomEnum({
+            val1: new CairoCustomEnum({
+              val1: 12,
+            }),
+          }),
+          bool_val: true,
+        },
+        event as any,
+        mockDeployedContractAbi.abi,
+      ),
+    ).toEqual([
+      ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
+      ["0x0"],
+      ["0x68656c6c6f20776f726c64"],
+      ["0xb"],
+      ["0x2703"],
+      ["0x0"],
+      ["0x2"],
+      ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
+      ["0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3"],
+      ["0x1"],
+      ["0x2"],
+      ["0x1"],
+      ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
     ]);
   });
 });

--- a/packages/nextjs/utils/scaffold-stark/__test__/mockDeployedContractAbi.ts
+++ b/packages/nextjs/utils/scaffold-stark/__test__/mockDeployedContractAbi.ts
@@ -1,0 +1,594 @@
+export const mockDeployedContractAbi = {
+  abi: [
+    {
+      type: "impl",
+      name: "YourContractImpl",
+      interface_name: "contracts::YourContract::IYourContract",
+    },
+    {
+      type: "struct",
+      name: "core::byte_array::ByteArray",
+      members: [
+        {
+          name: "data",
+          type: "core::array::Array::<core::bytes_31::bytes31>",
+        },
+        {
+          name: "pending_word",
+          type: "core::felt252",
+        },
+        {
+          name: "pending_word_len",
+          type: "core::integer::u32",
+        },
+      ],
+    },
+    {
+      type: "struct",
+      name: "core::integer::u256",
+      members: [
+        {
+          name: "low",
+          type: "core::integer::u128",
+        },
+        {
+          name: "high",
+          type: "core::integer::u128",
+        },
+      ],
+    },
+    {
+      type: "enum",
+      name: "core::bool",
+      variants: [
+        {
+          name: "False",
+          type: "()",
+        },
+        {
+          name: "True",
+          type: "()",
+        },
+      ],
+    },
+    {
+      type: "enum",
+      name: "contracts::YourContract::SimpleEnum",
+      variants: [
+        {
+          name: "val1",
+          type: "core::integer::u128",
+        },
+        {
+          name: "val2",
+          type: "core::starknet::contract_address::ContractAddress",
+        },
+      ],
+    },
+    {
+      type: "enum",
+      name: "contracts::YourContract::SomeEnum",
+      variants: [
+        {
+          name: "val1",
+          type: "contracts::YourContract::SimpleEnum",
+        },
+        {
+          name: "val2",
+          type: "core::starknet::contract_address::ContractAddress",
+        },
+        {
+          name: "val3",
+          type: "(core::integer::u128, core::integer::u256)",
+        },
+      ],
+    },
+    {
+      type: "enum",
+      name: "core::option::Option::<core::starknet::contract_address::ContractAddress>",
+      variants: [
+        {
+          name: "Some",
+          type: "core::starknet::contract_address::ContractAddress",
+        },
+        {
+          name: "None",
+          type: "()",
+        },
+      ],
+    },
+    {
+      type: "enum",
+      name: "core::option::Option::<core::integer::u128>",
+      variants: [
+        {
+          name: "Some",
+          type: "core::integer::u128",
+        },
+        {
+          name: "None",
+          type: "()",
+        },
+      ],
+    },
+    {
+      type: "struct",
+      name: "contracts::YourContract::SomeStruct",
+      members: [
+        {
+          name: "addr",
+          type: "core::option::Option::<core::starknet::contract_address::ContractAddress>",
+        },
+        {
+          name: "val",
+          type: "core::option::Option::<core::integer::u128>",
+        },
+      ],
+    },
+    {
+      type: "enum",
+      name: "contracts::YourContract::ComplexStruct",
+      variants: [
+        {
+          name: "val1",
+          type: "core::integer::u128",
+        },
+        {
+          name: "val2",
+          type: "core::array::Array::<(core::integer::u256, core::starknet::contract_address::ContractAddress)>",
+        },
+        {
+          name: "val3",
+          type: "core::array::Array::<contracts::YourContract::SomeStruct>",
+        },
+      ],
+    },
+    {
+      type: "interface",
+      name: "contracts::YourContract::IYourContract",
+      items: [
+        {
+          type: "function",
+          name: "greeting",
+          inputs: [],
+          outputs: [
+            {
+              type: "core::byte_array::ByteArray",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "set_greeting",
+          inputs: [
+            {
+              name: "new_greeting",
+              type: "core::byte_array::ByteArray",
+            },
+            {
+              name: "amount_eth",
+              type: "core::integer::u256",
+            },
+          ],
+          outputs: [],
+          state_mutability: "external",
+        },
+        {
+          type: "function",
+          name: "withdraw",
+          inputs: [],
+          outputs: [],
+          state_mutability: "external",
+        },
+        {
+          type: "function",
+          name: "premium",
+          inputs: [],
+          outputs: [
+            {
+              type: "core::bool",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "echo_enum",
+          inputs: [
+            {
+              name: "input",
+              type: "contracts::YourContract::SomeEnum",
+            },
+          ],
+          outputs: [
+            {
+              type: "contracts::YourContract::SomeEnum",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "echo_i16",
+          inputs: [
+            {
+              name: "input",
+              type: "core::integer::i16",
+            },
+          ],
+          outputs: [
+            {
+              type: "core::integer::i16",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "echo_struct",
+          inputs: [
+            {
+              name: "input",
+              type: "contracts::YourContract::SomeStruct",
+            },
+          ],
+          outputs: [
+            {
+              type: "contracts::YourContract::SomeStruct",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "echo_array",
+          inputs: [
+            {
+              name: "input",
+              type: "core::array::Array::<core::felt252>",
+            },
+          ],
+          outputs: [
+            {
+              type: "core::array::Array::<core::felt252>",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "echo_simple_tuple",
+          inputs: [
+            {
+              name: "input",
+              type: "(core::integer::u128, core::integer::u128)",
+            },
+          ],
+          outputs: [
+            {
+              type: "(core::integer::u128, core::integer::u128)",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "echo_u8",
+          inputs: [
+            {
+              name: "input",
+              type: "core::integer::u8",
+            },
+          ],
+          outputs: [
+            {
+              type: "core::integer::u8",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "echo_complex_struct",
+          inputs: [
+            {
+              name: "input",
+              type: "contracts::YourContract::ComplexStruct",
+            },
+          ],
+          outputs: [
+            {
+              type: "contracts::YourContract::ComplexStruct",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "echo_address",
+          inputs: [
+            {
+              name: "input",
+              type: "core::starknet::contract_address::ContractAddress",
+            },
+          ],
+          outputs: [
+            {
+              type: "core::starknet::contract_address::ContractAddress",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "echo_bool",
+          inputs: [
+            {
+              name: "input",
+              type: "core::bool",
+            },
+          ],
+          outputs: [
+            {
+              type: "core::bool",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "echo_str",
+          inputs: [
+            {
+              name: "input",
+              type: "core::byte_array::ByteArray",
+            },
+          ],
+          outputs: [
+            {
+              type: "core::byte_array::ByteArray",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "reply_complex_struct",
+          inputs: [
+            {
+              name: "input",
+              type: "core::integer::u8",
+            },
+          ],
+          outputs: [
+            {
+              type: "contracts::YourContract::ComplexStruct",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "send_events",
+          inputs: [
+            {
+              name: "input",
+              type: "core::integer::u8",
+            },
+          ],
+          outputs: [],
+          state_mutability: "external",
+        },
+      ],
+    },
+    {
+      type: "impl",
+      name: "OwnableImpl",
+      interface_name: "openzeppelin_access::ownable::interface::IOwnable",
+    },
+    {
+      type: "interface",
+      name: "openzeppelin_access::ownable::interface::IOwnable",
+      items: [
+        {
+          type: "function",
+          name: "owner",
+          inputs: [],
+          outputs: [
+            {
+              type: "core::starknet::contract_address::ContractAddress",
+            },
+          ],
+          state_mutability: "view",
+        },
+        {
+          type: "function",
+          name: "transfer_ownership",
+          inputs: [
+            {
+              name: "new_owner",
+              type: "core::starknet::contract_address::ContractAddress",
+            },
+          ],
+          outputs: [],
+          state_mutability: "external",
+        },
+        {
+          type: "function",
+          name: "renounce_ownership",
+          inputs: [],
+          outputs: [],
+          state_mutability: "external",
+        },
+      ],
+    },
+    {
+      type: "constructor",
+      name: "constructor",
+      inputs: [
+        {
+          name: "owner",
+          type: "core::starknet::contract_address::ContractAddress",
+        },
+      ],
+    },
+    {
+      type: "event",
+      name: "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferred",
+      kind: "struct",
+      members: [
+        {
+          name: "previous_owner",
+          type: "core::starknet::contract_address::ContractAddress",
+          kind: "key",
+        },
+        {
+          name: "new_owner",
+          type: "core::starknet::contract_address::ContractAddress",
+          kind: "key",
+        },
+      ],
+    },
+    {
+      type: "event",
+      name: "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferStarted",
+      kind: "struct",
+      members: [
+        {
+          name: "previous_owner",
+          type: "core::starknet::contract_address::ContractAddress",
+          kind: "key",
+        },
+        {
+          name: "new_owner",
+          type: "core::starknet::contract_address::ContractAddress",
+          kind: "key",
+        },
+      ],
+    },
+    {
+      type: "event",
+      name: "openzeppelin_access::ownable::ownable::OwnableComponent::Event",
+      kind: "enum",
+      variants: [
+        {
+          name: "OwnershipTransferred",
+          type: "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferred",
+          kind: "nested",
+        },
+        {
+          name: "OwnershipTransferStarted",
+          type: "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferStarted",
+          kind: "nested",
+        },
+      ],
+    },
+    {
+      type: "event",
+      name: "contracts::YourContract::YourContract::GreetingChanged",
+      kind: "struct",
+      members: [
+        {
+          name: "greeting_setter",
+          type: "core::starknet::contract_address::ContractAddress",
+          kind: "key",
+        },
+        {
+          name: "new_greeting",
+          type: "core::byte_array::ByteArray",
+          kind: "key",
+        },
+        {
+          name: "event_type",
+          type: "core::integer::u256",
+          kind: "key",
+        },
+        {
+          name: "premium",
+          type: "core::bool",
+          kind: "data",
+        },
+        {
+          name: "value",
+          type: "core::integer::u256",
+          kind: "data",
+        },
+        {
+          name: "addresses",
+          type: "core::array::Array::<core::starknet::contract_address::ContractAddress>",
+          kind: "key",
+        },
+        {
+          name: "arr",
+          type: "core::array::Array::<core::integer::u256>",
+          kind: "data",
+        },
+        {
+          name: "tup",
+          type: "(core::integer::u32, core::integer::u64, core::bool, core::starknet::contract_address::ContractAddress)",
+          kind: "key",
+        },
+        {
+          name: "st",
+          type: "contracts::YourContract::SomeStruct",
+          kind: "key",
+        },
+        {
+          name: "enum_val",
+          type: "contracts::YourContract::SomeEnum",
+          kind: "key",
+        },
+        {
+          name: "bool_val",
+          type: "core::bool",
+          kind: "key",
+        },
+      ],
+    },
+    {
+      type: "event",
+      name: "contracts::YourContract::YourContract::EventPanic",
+      kind: "struct",
+      members: [
+        {
+          name: "error_type",
+          type: "core::integer::u8",
+          kind: "key",
+        },
+        {
+          name: "setter",
+          type: "core::starknet::contract_address::ContractAddress",
+          kind: "key",
+        },
+        {
+          name: "error_description",
+          type: "core::felt252",
+          kind: "data",
+        },
+      ],
+    },
+    {
+      type: "event",
+      name: "contracts::YourContract::YourContract::Event",
+      kind: "enum",
+      variants: [
+        {
+          name: "OwnableEvent",
+          type: "openzeppelin_access::ownable::ownable::OwnableComponent::Event",
+          kind: "flat",
+        },
+        {
+          name: "GreetingChanged",
+          type: "contracts::YourContract::YourContract::GreetingChanged",
+          kind: "nested",
+        },
+        {
+          name: "EventPanic",
+          type: "contracts::YourContract::YourContract::EventPanic",
+          kind: "nested",
+        },
+      ],
+    },
+  ],
+};

--- a/packages/nextjs/utils/scaffold-stark/contract.ts
+++ b/packages/nextjs/utils/scaffold-stark/contract.ts
@@ -370,7 +370,7 @@ export type UseScaffoldEventHistoryConfig<
   contractName: TContractName;
   eventName: IsContractDeclarationMissing<string, TEventName>;
   fromBlock: bigint;
-  filters?: any;
+  filters?: { [key: string]: any };
   blockData?: TBlockData;
   transactionData?: TTransactionData;
   receiptData?: TReceiptData;

--- a/packages/nextjs/utils/scaffold-stark/eventKeyFilter.ts
+++ b/packages/nextjs/utils/scaffold-stark/eventKeyFilter.ts
@@ -1,0 +1,76 @@
+import {
+  ExtractAbiEvent,
+  ExtractAbiEventNames,
+} from "abi-wan-kanabi/dist/kanabi";
+import { AbiEntry, AbiEnums, AbiStructs, parseCalldataField } from "starknet";
+import { ContractAbi, ContractName } from "./contract";
+
+const stringToHexString = (numStr: string) => {
+  const bigIntValue = BigInt(numStr);
+  const hexString = bigIntValue.toString(16);
+  return `0x${hexString}`;
+};
+
+const stringToByteArrayFelt = (str: string): string[] => {
+  const bytes = new TextEncoder().encode(str);
+  const result = [];
+  const numFullWords = Math.floor(bytes.length / 31);
+  result.push(numFullWords.toString());
+
+  for (let i = 0; i < numFullWords; i++) {
+    const chunk = bytes.slice(i * 31, (i + 1) * 31);
+    const felt = "0x" + Buffer.from(chunk).toString("hex");
+    result.push(felt);
+  }
+
+  const remainingBytes = bytes.slice(numFullWords * 31);
+  if (remainingBytes.length > 0) {
+    const pendingWord = "0x" + Buffer.from(remainingBytes).toString("hex");
+    result.push(pendingWord);
+  } else {
+    result.push("0x0");
+  }
+
+  result.push(remainingBytes.length.toString());
+  return result;
+};
+
+export const serializeEventKey = (
+  input: any,
+  abiEntry: AbiEntry,
+  structs: AbiStructs,
+  enums: AbiEnums,
+): string[] => {
+  if (abiEntry.type === "core::byte_array::ByteArray") {
+    return stringToByteArrayFelt(input).map((item) => stringToHexString(item));
+  }
+  const args = [input][Symbol.iterator]();
+  const parsed = parseCalldataField(args, abiEntry, structs, enums);
+  if (typeof parsed === "string") {
+    return [stringToHexString(parsed)];
+  }
+  return parsed.map((item: string) => stringToHexString(item));
+};
+
+export const composeEventFilterKeys = (
+  input: { [key: string]: any },
+  event: ExtractAbiEvent<
+    ContractAbi<ContractName>,
+    ExtractAbiEventNames<ContractAbi<ContractName>>
+  >,
+  structs: AbiStructs,
+  enums: AbiEnums,
+): string[] => {
+  if (!("members" in event)) {
+    return [];
+  }
+  let keys: string[] = [];
+  for (const member of event.members) {
+    if (member.kind === "key" && member.name in input) {
+      keys = keys.concat(
+        serializeEventKey(input[member.name], member, structs, enums),
+      );
+    }
+  }
+  return keys;
+};

--- a/packages/nextjs/utils/scaffold-stark/eventKeyFilter.ts
+++ b/packages/nextjs/utils/scaffold-stark/eventKeyFilter.ts
@@ -11,12 +11,7 @@ import {
   parseCalldataField,
 } from "starknet";
 import { ContractAbi, ContractName } from "./contract";
-
-const stringToHexString = (numStr: string) => {
-  const bigIntValue = BigInt(numStr);
-  const hexString = bigIntValue.toString(16);
-  return `0x${hexString}`;
-};
+import { feltToHex } from "./common";
 
 const stringToByteArrayFelt = (str: string): string[] => {
   const bytes = new TextEncoder().encode(str);
@@ -49,14 +44,14 @@ export const serializeEventKey = (
   enums: AbiEnums,
 ): string[] => {
   if (abiEntry.type === "core::byte_array::ByteArray") {
-    return stringToByteArrayFelt(input).map((item) => stringToHexString(item));
+    return stringToByteArrayFelt(input).map((item) => feltToHex(BigInt(item)));
   }
   const args = [input][Symbol.iterator]();
   const parsed = parseCalldataField(args, abiEntry, structs, enums);
   if (typeof parsed === "string") {
-    return [stringToHexString(parsed)];
+    return [feltToHex(BigInt(parsed))];
   }
-  return parsed.map((item: string) => stringToHexString(item));
+  return parsed.map((item: string) => feltToHex(BigInt(item)));
 };
 
 const is2DArray = (arr: any) => {


### PR DESCRIPTION
# Event key filter

Support event filter

## Types of change

- [x] Feature
- [ ] Bug
- [ ] Enhancement

## Comments

doc pull request: https://github.com/Scaffold-Stark/ss2-docs/pull/88

Reference the implementation of `starknet_getEvents` endpoint in `starknet-devnet-rs`, filter logic is in `crates/starknet-devnet-core/src/starknet/events.rs`

```
/// This method checks if the keys apply to the keys_filter and returns true or false
///
/// # Arguments
/// * `keys_filter` - Optional. The values to filter the keys by.
/// * `keys` - The keys to check if they apply to the filter.
fn check_if_filter_applies_for_event_keys<T>(keys_filter: &Option<Vec<Vec<T>>>, keys: &[T]) -> bool
where
    T: PartialEq + Eq,
{
    match &keys_filter {
        Some(keys_filter) => {
            for (event_key, accepted_keys) in keys.iter().zip(keys_filter) {
                if !accepted_keys.is_empty() && !accepted_keys.contains(event_key) {
                    return false;
                }
            }

            true
        }
        None => true,
    }
}
```
### Basic case
The filter can only be applied to event keys, which is event field with `#[key]` annotation. For example, an event defined in contract like this:
```
#[derive(Drop, starknet::Event)]
    struct GreetingChanged {
        #[key]
        from: ContractAddress,
        #[key]
        to: ContractAddress,
        new_greeting: ByteArray,
    }
```
the event data will include an `keys` array:
```
[
    "0x30a5b63b12d63c3c34bd7145a56f903aa6e641b727d42ff159af4372c62e008",
    "0x65dc4a1c484bcde864e7eebc55f033f2baf57dc6e2f4eae14c6860836cfcd0e",
    "0xdac9bcf0bc21a9f3483d47a8ade4764ee5c0377b3bcddf2df477e3c1e55810"
]
```
The first element is the hash result of event name, the second one is the first key `from`, and the third one is the second key `to`.

If want provide the the filter keys, it must be a 2-dimension array like this:
```
[
    ["0x30a5b63b12d63c3c34bd7145a56f903aa6e641b727d42ff159af4372c62e008"],
    ["0x65dc4a1c484bcde864e7eebc55f033f2baf57dc6e2f4eae14c6860836cfcd0e"],
    ["0xdac9bcf0bc21a9f3483d47a8ade4764ee5c0377b3bcddf2df477e3c1e55810"]
]
```
and if you want filter out the `from` with `addressA` or `addressB`, then the keys should be:
```
[
    ["0x30a5b63b12d63c3c34bd7145a56f903aa6e641b727d42ff159af4372c62e008"],
    [
        "0x65dc4a1c484bcde864e7eebc55f033f2baf57dc6e2f4eae14c6860836cfcd0e", 
        "0x043d50AdDC63f86eB960641CD289558DA3348D0EA3451B8707Da29d329100077"
    ],
    ["0xdac9bcf0bc21a9f3483d47a8ade4764ee5c0377b3bcddf2df477e3c1e55810"]
]
```

### Complex key
For event, the key can be more complex type, like struct, enum or tuple. here is a complex case:
```
#[derive(Drop, starknet::Event)]
struct GreetingChanged {
    #[key]
    greeting_setter: ContractAddress,
    #[key]
    new_greeting: ByteArray,
    #[key]
    event_type: u256,
    premium: bool,
    value: u256,
    #[key]
    addresses: Array<ContractAddress>,
    arr: Array<u256>,
    #[key]
    tup: (u32, u64, bool, ContractAddress),
    #[key]
    st: SomeStruct,
    #[key]
    enum_val: SomeEnum,
    #[key]
    bool_val: bool,
    #[key]
    size_val: usize,
}

#[derive(Drop, Serde)]
struct SomeStruct {
    addr: Option<ContractAddress>,
    val: Option<u128>,
}
#[derive(Drop, Serde)]
enum SimpleEnum {
    val1: u128,
    val2: ContractAddress,
}
#[derive(Drop, Serde)]
enum SomeEnum {
    val1: SimpleEnum,
    val2: ContractAddress,
    val3: (u128, u256),
}
```
If you want filter out the event emit like this:
```
GreetingChanged {
    greeting_setter: get_caller_address(),
    new_greeting: "hello world",
    event_type: 9987,
    premium: true,
    value: 256,
    addresses: array![get_caller_address(), get_contract_address()],
    arr: array![1, 2],
    tup: (1, 2, true, get_caller_address()),
    st: SomeStruct {
        addr: Option::Some(get_caller_address()), val: Option::None,
    },
    enum_val: SomeEnum::val1(SimpleEnum::val1(12)),
    bool_val: true,
    size_val: 2,
},
```
then then the filter keys should be:
```
[
  ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
  ["0x0"],
  ["0x68656c6c6f20776f726c64"],
  ["0xb"],
  ["0x2703"],
  ["0x0"],
  ["0x2"],
  ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
  ["0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3"],
  ["0x1"],
  ["0x2"],
  ["0x1"],
  ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
  ["0x0"],
  ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
  ["0x1"],
  ["0x0"],
  ["0x0"],
  ["0xc"],
  ["0x1"],
  ["0x2"],
]
```
the keys need to be serialised, reference: https://docs.starknet.io/architecture-and-concepts/smart-contracts/serialization-of-cairo-types/#additional_resources 

### How to use it in `useScaffoldEventHistory`
```
useScaffoldEventHistory({
  contractName: "YourContract",
  eventName: "contracts::YourContract::YourContract::GreetingChanged",
  fromBlock: 0n,
  filters: {
    greeting_setter: ["0x00daC9BCF0bC21a9f3483D47A8Ade4764EE5c0377B3bCDDf2df477E3C1e55810"],
    new_greeting: "hello world",
    event_type: 9987n,
    addresses: [
        "0x00daC9BCF0bC21a9f3483D47A8Ade4764EE5c0377B3bCDDf2df477E3C1e55810", 
        "0x065Dc4A1C484bcde864e7eEBc55F033F2BAF57dc6e2f4eaE14c6860836CFcd0E"
    ],
    tup: {
      0: 1n,
      1: 2n,
      2: true,
      3: caller,
    },
    st: {
      addr: new CairoOption(CairoOptionVariant.Some, caller),
      val: new CairoOption(CairoOptionVariant.None),
    },
    enum_val: new CairoCustomEnum({
      val1: new CairoCustomEnum({
        val1: 12,
      }),
    }),
    bool_val: true,
  },
});
```
more examples can be checked in unit test `eventKeyFilter.test.ts`

### Limitation
1. in devnet there is no filter keys count limitation, but in sepolia, as I tested, the limitation is `16`
2. for `any` filter, it can only be applied to the data type which is fix length after serialization. as the test case:
```
it("should compose event filter keys break when include any for uncertain length type", () => {
  expect(
    composeEventFilterKeys(
      {
        greeting_setter:
          "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
        new_greeting: "hello world",
        event_type: 9987n,
        addresses: [
          "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
          "0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3",
        ],
        tup: {
          0: 1n,
          1: 2n,
          2: true,
          3: "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
        },
        enum_val: new CairoCustomEnum({
          val1: new CairoCustomEnum({
            val1: 12,
          }),
        }),
        bool_val: true,
      },
      event as any,
      mockDeployedContractAbi.abi,
    ),
  ).toEqual([
    ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
    ["0x0"],
    ["0x68656c6c6f20776f726c64"],
    ["0xb"],
    ["0x2703"],
    ["0x0"],
    ["0x2"],
    ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
    ["0x6a1991c289bda4d029f9acee45b37c0f4ed86d0c35d977ed320f8594afaa0b3"],
    ["0x1"],
    ["0x2"],
    ["0x1"],
    ["0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691"],
  ]);
});
```