### PR TITLE
fix: correct address regex in AddressInput

### DIFF
--- a/packages/nextjs/components/scaffold-stark/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-stark/Input/AddressInput.tsx
@@ -28,14 +28,8 @@ export const AddressInput = ({
         return;
       }
 
-      const isValid =
-        /^(0x)([a-fA-F0-9]{40})$/.test(sanitizedValue) &&
-        !/0x.*0x/.test(sanitizedValue);
+      const isValid = /^0x[a-f0-9]{1,64}$/.test(sanitizedValue);
       if (!isValid) {
-        return;
-      }
-
-      if (sanitizedValue.length !== 42) {
         return;
       }
 

--- a/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
+++ b/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
@@ -28,7 +28,7 @@ function main() {
 
   if (argv._.length > 0) {
     console.error(
-      `❌ Invalid arguments, only --network, --fee, or --reset/--no-reset can be passed in`,
+      `❌ Invalid arguments, only --network, --fee, or --reset/--no-reset can be passed in`
     );
     return;
   }
@@ -41,7 +41,7 @@ function main() {
         ` --fee ${argv.fee || "eth"}` +
         ` ${!argv.reset && "--no-reset "}` +
         ` && ts-node ../scripts-ts/helpers/parse-deployments.ts && cd ..`,
-      { stdio: "inherit" },
+      { stdio: "inherit" }
     );
   } catch (error) {
     console.error("Error during deployment:", error);


### PR DESCRIPTION
# Fix address check in AddressInput

Fixes #420

## Types of change

- [ ] Feature
- [x] Bug
- [ ] Enhancement

## Comments (optional)
Changes made:
1. Updated the regex to `/^0x[a-f0-9]{1,64}$/` which:
   - Matches `0x` prefix
   - Followed by 1-64 hex characters (a-f, 0-9)
   - No need for capture groups or additional checks
2. Removed the redundant length check since it's handled by the regex
3. Removed the redundant double-0x check since the regex ensures only one 0x at the start
4. Fixed formatting issues in `deploy-wrapper.ts`

The validation is now more appropriate for Starknet addresses while being simpler and more maintainable.

