### PR TITLE
chore(docs): fix incorrect Starknet Foundry version in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If your local Scarb version is not `2.9.2`, you need to install it.
 
 ### Starknet Foundry version
 
-To ensure the proper functioning of the tests on scaffold-stark, your Starknet Foundry version must be 0.31.0. To accomplish this, first check your Starknet Foundry version:
+To ensure the proper functioning of the tests on scaffold-stark, your Starknet Foundry version must be 0.35.1. To accomplish this, first check your Starknet Foundry version:
 
 ```sh
 snforge --version


### PR DESCRIPTION
# Fix incorrect Starknet Foundry version in documentation

## Types of change

- [ ] Feature
- [ ] Bug
- [x] Enhancement

## Comments (optional)
This PR corrects the version mismatch in the documentation for Starknet Foundry. The required version is updated to 0.35.1, aligning with the compatible versions section to avoid user confusion.