### PR TITLE
Cache getClassHash request and result

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/ContractClassHashCache.ts
+++ b/packages/nextjs/hooks/scaffold-stark/ContractClassHashCache.ts
@@ -1,0 +1,70 @@
+import { BlockIdentifier, ProviderInterface } from "starknet";
+
+export class ContractClassHashCache {
+  private static instance: ContractClassHashCache;
+  private cache = new Map<string, string>();
+  private pendingRequests = new Map<string, Promise<string | undefined>>();
+
+  private constructor() {}
+
+  public static getInstance(): ContractClassHashCache {
+    if (!ContractClassHashCache.instance) {
+      ContractClassHashCache.instance = new ContractClassHashCache();
+    }
+    return ContractClassHashCache.instance;
+  }
+
+  public async getClassHash(
+    publicClient: ProviderInterface,
+    address: string,
+    blockIdentifier: BlockIdentifier = "pending",
+  ): Promise<string | undefined> {
+    const cacheKey = `${address}-${blockIdentifier}`;
+
+    if (this.cache.has(cacheKey)) {
+      return this.cache.get(cacheKey);
+    }
+
+    if (this.pendingRequests.has(cacheKey)) {
+      return this.pendingRequests.get(cacheKey);
+    }
+
+    const pendingRequest = this.fetchClassHash(
+      publicClient,
+      address,
+      blockIdentifier,
+      cacheKey,
+    );
+    this.pendingRequests.set(cacheKey, pendingRequest);
+
+    try {
+      return await pendingRequest;
+    } finally {
+      this.pendingRequests.delete(cacheKey);
+    }
+  }
+
+  private async fetchClassHash(
+    publicClient: ProviderInterface,
+    address: string,
+    blockIdentifier: BlockIdentifier,
+    cacheKey: string,
+  ): Promise<string | undefined> {
+    try {
+      const classHash = await publicClient.getClassHashAt(
+        address,
+        blockIdentifier,
+      );
+      this.cache.set(cacheKey, classHash);
+      return classHash;
+    } catch (error) {
+      console.error("Failed to fetch class hash:", error);
+      return undefined;
+    }
+  }
+
+  public clear(): void {
+    this.cache.clear();
+    this.pendingRequests.clear();
+  }
+}

--- a/packages/nextjs/hooks/scaffold-stark/__tests__/ContractClassHashCache.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/ContractClassHashCache.test.ts
@@ -11,7 +11,6 @@ describe("ContractClassHashCache", () => {
   };
 
   beforeEach(() => {
-    // 重置单例
     cache = ContractClassHashCache.getInstance();
     cache.clear();
     vi.clearAllMocks();

--- a/packages/nextjs/hooks/scaffold-stark/__tests__/ContractClassHashCache.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/ContractClassHashCache.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
+import { ContractClassHashCache } from "../ContractClassHashCache";
+import { ProviderInterface } from "starknet";
+
+describe("ContractClassHashCache", () => {
+  let cache: ContractClassHashCache;
+
+  // Mock provider
+  const mockProvider: Partial<ProviderInterface> = {
+    getClassHashAt: vi.fn(),
+  };
+
+  beforeEach(() => {
+    // 重置单例
+    cache = ContractClassHashCache.getInstance();
+    cache.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should be a singleton", () => {
+    const instance1 = ContractClassHashCache.getInstance();
+    const instance2 = ContractClassHashCache.getInstance();
+    expect(instance1).toBe(instance2);
+  });
+
+  it("should cache class hash results", async () => {
+    const address = "0x123";
+    const expectedHash = "0xabc";
+
+    vi.mocked(mockProvider.getClassHashAt)!.mockResolvedValueOnce(expectedHash);
+
+    // First call should fetch from provider
+    const result1 = await cache.getClassHash(
+      mockProvider as ProviderInterface,
+      address,
+    );
+
+    // Second call should use cache
+    const result2 = await cache.getClassHash(
+      mockProvider as ProviderInterface,
+      address,
+    );
+
+    expect(result1).toBe(expectedHash);
+    expect(result2).toBe(expectedHash);
+    expect(mockProvider.getClassHashAt).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle provider errors", async () => {
+    const address = "0x123";
+
+    vi.mocked(mockProvider.getClassHashAt)!.mockRejectedValueOnce(
+      new Error("API Error"),
+    );
+
+    const result = await cache.getClassHash(
+      mockProvider as ProviderInterface,
+      address,
+    );
+
+    expect(result).toBeUndefined();
+    expect(mockProvider.getClassHashAt).toHaveBeenCalledTimes(1);
+  });
+
+  it("should deduplicate concurrent requests", async () => {
+    const address = "0x123";
+    const expectedHash = "0xabc";
+
+    vi.mocked(mockProvider.getClassHashAt)!.mockImplementation(
+      () =>
+        new Promise((resolve) => setTimeout(() => resolve(expectedHash), 100)),
+    );
+
+    // Make multiple concurrent requests
+    const promises = Array(3)
+      .fill(null)
+      .map(() =>
+        cache.getClassHash(mockProvider as ProviderInterface, address),
+      );
+
+    const results = await Promise.all(promises);
+
+    // All requests should return the same result
+    results.forEach((result) => expect(result).toBe(expectedHash));
+    // Provider should only be called once
+    expect(mockProvider.getClassHashAt).toHaveBeenCalledTimes(1);
+  });
+
+  it("should use different cache keys for different block identifiers", async () => {
+    const address = "0x123";
+    const hash1 = "0xabc";
+    const hash2 = "0xdef";
+
+    vi.mocked(mockProvider.getClassHashAt)!
+      .mockResolvedValueOnce(hash1)
+      .mockResolvedValueOnce(hash2);
+
+    const result1 = await cache.getClassHash(
+      mockProvider as ProviderInterface,
+      address,
+      "pending",
+    );
+
+    const result2 = await cache.getClassHash(
+      mockProvider as ProviderInterface,
+      address,
+      "latest",
+    );
+
+    expect(result1).toBe(hash1);
+    expect(result2).toBe(hash2);
+    expect(mockProvider.getClassHashAt).toHaveBeenCalledTimes(2);
+  });
+
+  it("should clear cache when requested", async () => {
+    const address = "0x123";
+    const expectedHash = "0xabc";
+
+    vi.mocked(mockProvider.getClassHashAt)!.mockResolvedValue(expectedHash);
+
+    // First call
+    await cache.getClassHash(mockProvider as ProviderInterface, address);
+
+    // Clear cache
+    cache.clear();
+
+    // Second call should fetch again
+    await cache.getClassHash(mockProvider as ProviderInterface, address);
+
+    expect(mockProvider.getClassHashAt).toHaveBeenCalledTimes(2);
+  });
+
+  it("should handle multiple addresses independently", async () => {
+    const address1 = "0x123";
+    const address2 = "0x456";
+    const hash1 = "0xabc";
+    const hash2 = "0xdef";
+
+    vi.mocked(mockProvider.getClassHashAt)!
+      .mockResolvedValueOnce(hash1)
+      .mockResolvedValueOnce(hash2);
+
+    const result1 = await cache.getClassHash(
+      mockProvider as ProviderInterface,
+      address1,
+    );
+
+    const result2 = await cache.getClassHash(
+      mockProvider as ProviderInterface,
+      address2,
+    );
+
+    expect(result1).toBe(hash1);
+    expect(result2).toBe(hash2);
+    expect(mockProvider.getClassHashAt).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/nextjs/hooks/scaffold-stark/useDeployedContractInfo.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useDeployedContractInfo.ts
@@ -9,6 +9,7 @@ import {
 } from "~~/utils/scaffold-stark/contract";
 import { BlockIdentifier } from "starknet";
 import { useProvider } from "@starknet-react/core";
+import { ContractClassHashCache } from "./ContractClassHashCache";
 
 export const useDeployedContractInfo = <TContractName extends ContractName>(
   contractName: TContractName,
@@ -30,18 +31,12 @@ export const useDeployedContractInfo = <TContractName extends ContractName>(
         return;
       }
 
-      let contractClassHash: string | undefined = undefined;
-      try {
-        contractClassHash = await publicClient.getClassHashAt(
-          deployedContract.address,
-          "pending" as BlockIdentifier,
-        );
-      } catch (error) {
-        console.error(
-          "⚡️ ~ file: useDeployedContractInfo.ts:useEffect ~ error",
-          error,
-        );
-      }
+      const classHashCache = ContractClassHashCache.getInstance();
+      const contractClassHash = await classHashCache.getClassHash(
+        publicClient,
+        deployedContract.address,
+        "pending" as BlockIdentifier,
+      );
 
       if (!isMounted()) {
         return;


### PR DESCRIPTION
# Cache getClassHash request and result

## Types of change

- [ ] Feature
- [ ] Bug
- [x] Enhancement

## Comments

We use `useDeployedContractInfo` in many places, then the `getClassHashAt` API is triggered significantly more times than actually needed. When we provide provider url in env file, it will cause http 429 error.
<img width="1342" alt="image" src="https://github.com/user-attachments/assets/f30f7589-1304-4b6a-8d57-12e303cf8a20" />
<img width="1841" alt="image" src="https://github.com/user-attachments/assets/8266210b-449d-4de6-9dff-0e26625fac66" />

In this PR, added a singleton instance to handle the cache,  it will reuse the api call as well.
