### PR TITLE
Fixed .env.example

### DIFF
--- a/packages/nextjs/.env.example
+++ b/packages/nextjs/.env.example
@@ -1,2 +1,12 @@
-NEXT_PUBLIC_PROVIDER_URL=https://starknet-sepolia.blastapi.io/64168c77-3fa5-4e1e-9fe4-41675d212522/rpc/v0_7
-NEXT_PUBLIC_RPC_URL_DEVNET=http://localhost:5050
+NEXT_PUBLIC_PROVIDER_URL=http://localhost:5050  
+
+# URL Devnet
+NEXT_PUBLIC_DEVNET_PROVIDER_URL=http://localhost:5050
+
+# URL Sepolia
+# NEXT_PUBLIC_SEPOLIA_PROVIDER_URL=https://starknet-sepolia.blastapi.io/64168c77-3fa5-4e1e-9fe4-41675d212522/rpc/v0_7
+
+# URL Mainnet
+# NEXT_PUBLIC_MAINNET_PROVIDER_URL=https://starknet-mainnet.blastapi.io/64168c77-3fa5-4e1e-9fe4-41675d212522/rpc/v0_7
+
+


### PR DESCRIPTION
# RPC Configuration Fix for Correct UI Display

I found that in the `.env.example` file, under the new **[RPC-centralized](https://github.com/Scaffold-Stark/scaffold-stark-2/issues/445)** configuration, the UI was not displaying values correctly. This was due to an incorrect configuration of values in the `.env.local` or `.env` files. 

## Types of change

- [ ] Feature
- [x] Bug
- [ ] Enhancement

### **Changes made:**
 **Updated `.env.example` configuration:**
   - Corrected and standardized the format of the RPC URLs for **Sepolia**, **Mainnet**, and **Devnet**.
   - The environment variables are now correctly applied and formatted to ensure the UI displays values properly.

