### PR TITLE
fix(deploy): align help text with CLI behavior (#454)

### DIFF
--- a/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
+++ b/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
@@ -19,10 +19,10 @@ function main() {
       default: "devnet",
     })
     .option("fee", { type: "string", choices: ["eth", "strk"], default: "eth" })
-    .option("no-reset", {
+    .option("reset", {
       type: "boolean",
-      description: "Do not reset deployments (keep existing deployments)",
-      default: false,
+      description: "Reset deployments (clear existing deployments)",
+      default: true,
     })
     .demandOption(["network", "fee"])
     .parseSync() as CommandLineOptions;
@@ -40,7 +40,7 @@ function main() {
       `cd contracts && scarb build && ts-node ../scripts-ts/deploy.ts` +
         ` --network ${argv.network || "devnet"}` +
         ` --fee ${argv.fee || "eth"}` +
-        ` ${argv["no-reset"] ? "--no-reset" : ""}` +
+        ` ${!argv.reset ? "--no-reset" : ""}` +
         ` && ts-node ../scripts-ts/helpers/parse-deployments.ts && cd ..`,
       { stdio: "inherit" }
     );

--- a/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
+++ b/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
@@ -8,7 +8,6 @@ interface CommandLineOptions {
   network?: string; // The --network option
   reset?: boolean;
   fee?: string;
-  "no-reset"?: boolean;
 }
 
 function main() {
@@ -29,18 +28,17 @@ function main() {
 
   if (argv._.length > 0) {
     console.error(
-      `❌ Invalid arguments, only --network, --fee, or --reset/--no-reset can be passed in`
+      `❌ Invalid arguments, only --network, --fee, or --reset can be passed in`
     );
     return;
   }
 
-  // Execute the deploy script without the reset option
+  // Execute the deploy script - yargs will automatically handle --no-reset
   try {
     execSync(
       `cd contracts && scarb build && ts-node ../scripts-ts/deploy.ts` +
         ` --network ${argv.network || "devnet"}` +
         ` --fee ${argv.fee || "eth"}` +
-        ` ${!argv.reset ? "--no-reset" : ""}` +
         ` && ts-node ../scripts-ts/helpers/parse-deployments.ts && cd ..`,
       { stdio: "inherit" }
     );

--- a/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
+++ b/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
@@ -8,6 +8,7 @@ interface CommandLineOptions {
   network?: string; // The --network option
   reset?: boolean;
   fee?: string;
+  "no-reset"?: boolean;
 }
 
 function main() {
@@ -18,12 +19,12 @@ function main() {
       default: "devnet",
     })
     .option("fee", { type: "string", choices: ["eth", "strk"], default: "eth" })
-    .option("reset", {
+    .option("no-reset", {
       type: "boolean",
       description: "Do not reset deployments (keep existing deployments)",
-      default: true,
+      default: false,
     })
-    .demandOption(["network", "fee", "reset"])
+    .demandOption(["network", "fee"])
     .parseSync() as CommandLineOptions;
 
   if (argv._.length > 0) {
@@ -39,7 +40,7 @@ function main() {
       `cd contracts && scarb build && ts-node ../scripts-ts/deploy.ts` +
         ` --network ${argv.network || "devnet"}` +
         ` --fee ${argv.fee || "eth"}` +
-        ` ${!argv.reset && "--no-reset "}` +
+        ` ${argv["no-reset"] ? "--no-reset" : ""}` +
         ` && ts-node ../scripts-ts/helpers/parse-deployments.ts && cd ..`,
       { stdio: "inherit" }
     );

--- a/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
+++ b/packages/snfoundry/scripts-ts/helpers/deploy-wrapper.ts
@@ -39,6 +39,7 @@ function main() {
       `cd contracts && scarb build && ts-node ../scripts-ts/deploy.ts` +
         ` --network ${argv.network || "devnet"}` +
         ` --fee ${argv.fee || "eth"}` +
+        ` ${argv.reset ? "--reset" : "--no-reset"}` +
         ` && ts-node ../scripts-ts/helpers/parse-deployments.ts && cd ..`,
       { stdio: "inherit" }
     );


### PR DESCRIPTION
# Fix deploy CLI help text

Fixes #454

## Types of change

- [ ] Feature
- [x] Bug
- [ ] Enhancement

## Comments 

Changed `--reset` to `--no-reset` flag in help text to match package.json commands. Screenshot shows successful implementation:


<img width="581" alt="Screenshot 2025-03-16 at 1 14 03 AM" src="https://github.com/user-attachments/assets/c520d90b-ae17-4061-9e04-b52257ce6bfd" />
