### PR TITLE
[BUG] Add pwa in nextjs dependencies

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -35,6 +35,7 @@
     "ethers": "^6.12.0",
     "get-starknet-core": "^4.0.0",
     "next": "14.1.3",
+    "next-pwa": "^5.6.0",
     "next-themes": "^0.2.1",
     "nprogress": "^0.2.0",
     "prettier": "^3.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3635,6 +3635,7 @@ __metadata:
     get-starknet-core: ^4.0.0
     jsdom: ^25.0.1
     next: 14.1.3
+    next-pwa: ^5.6.0
     next-themes: ^0.2.1
     nprogress: ^0.2.0
     postcss: ^8


### PR DESCRIPTION
# Task name here

Integrate PWA into NextJS dependencies, otherwise the "yarn deploy:yolo" options will fail.

![imagen](https://github.com/user-attachments/assets/7d384a93-d1e9-4024-b158-3ec9d8756efa)
![Captura desde 2025-03-17 09-55-41](https://github.com/user-attachments/assets/ae931c2d-3e1f-4eb0-a237-656d392756b7)

## Types of change

- [x] Bug

