### PR TITLE
Update Docker

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Scaffold Stark",
-    "image": "starknetfoundation/starknet-dev:2.9.4",
+    "image": "starknetfoundation/starknet-dev:2.11.3",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ As an alternative to installing the tools locally, you can use Docker. Here's wh
 1. Install [Docker](https://www.docker.com/get-started/)
 2. Install [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 3. Use the provided `devcontainer.json` file to set up the environment:
-   - The configuration uses the `starknetfoundation/starknet-dev:2.9.2` image.
+   - The configuration uses the `starknetfoundation/starknet-dev:2.11.3` image.
    - This includes all required tools pre-installed, such as Scarb, Starknet Foundry, Starknet Devnet and other dependencies.
 
 ### Getting Started with Docker Setup

--- a/packages/snfoundry/contracts/Scarb.toml
+++ b/packages/snfoundry/contracts/Scarb.toml
@@ -18,6 +18,9 @@ snforge_std = "0.38.2"
 [[target.starknet-contract]]
 casm = true
 
+[tool.scarb]
+allow-prebuilt-plugins = ["snforge_std"]
+
 [tool.fmt]
 sort-module-level-items = true
 


### PR DESCRIPTION
# New version of the Docker image

### Version supporting:
- Scarb **2.11.3** (Cairo and Starknet **2.11.2**)  
- Starknet Foundry **0.40.0**  
- Starknet Devnet **0.3.0**  

To use the precompiled version of the dependency, add this configuration to `Scarb.toml`:  

```toml
[tool.scarb]
allow-prebuilt-plugins = ["snforge_std"]
```

## Type of Change

- [ ] Feature  
- [ ] Bug  
- [x] Enhancement  

