### PR TITLE
refactor: add warn for empty RPC Provider URL config in next .env

### DIFF
--- a/packages/nextjs/services/web3/provider.ts
+++ b/packages/nextjs/services/web3/provider.ts
@@ -19,6 +19,15 @@ const currentNetworkName = currentNetwork.network;
 // Get RPC URL for the current network
 const rpcUrl = scaffoldConfig.rpcProviderUrl[currentNetworkName] || "";
 
+// Important: if the rpcUrl is empty (not configed in .env), we use the publicProvider
+// which randomly choose a provider from the chain list of public providers. 
+// Some public provider might have strict rate limits.
+if (rpcUrl === "") {
+  console.warn(
+    `No RPC Provider URL configured for ${currentNetworkName}. Using public provider.`
+  );
+}
+
 const provider =
   rpcUrl === "" || containsDevnet(scaffoldConfig.targetNetworks)
     ? publicProvider()


### PR DESCRIPTION
# Add warn for empty RPC Provider URL config in next .env

## Types of change

- [ ] Feature
- [ ] Bug
- [X] Enhancement

## Changes
- Add warn for empty RPC Provider URL config in next .env