### PR TITLE
Fix: Fast Reload not working on testnet mode

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
@@ -117,6 +117,7 @@ export const WriteOnlyFunctionForm = ({
     setDisplayedTxResult(
       txResult as unknown as InvokeTransactionReceiptResponse,
     );
+    onChange();
   }, [txResult]);
 
   // TODO use `useMemo` to optimize also update in ReadOnlyFunctionForm

--- a/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
@@ -13,11 +13,7 @@ import {
   isError,
 } from "~~/app/debug/_components/contract";
 import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";
-import {
-  useSendTransaction,
-  useNetwork,
-  useContract,
-} from "@starknet-react/core";
+import { useNetwork, useContract } from "@starknet-react/core";
 import { Abi } from "abi-wan-kanabi";
 import { AbiFunction } from "~~/utils/scaffold-stark/contract";
 import { Address } from "@starknet-react/chains";
@@ -47,7 +43,11 @@ export const WriteOnlyFunctionForm = ({
     useState<FormErrorMessageState>({});
   const { status: walletStatus, isConnected, account, chainId } = useAccount();
   const { chain } = useNetwork();
-  const { writeTransaction, transactionReceiptInstance } = useTransactor();
+  const {
+    writeTransaction,
+    transactionReceiptInstance,
+    sendTransactionInstance,
+  } = useTransactor();
   const { data: txResult } = transactionReceiptInstance;
   const { targetNetwork } = useTargetNetwork();
 
@@ -64,12 +64,7 @@ export const WriteOnlyFunctionForm = ({
     address: contractAddress,
   });
 
-  const {
-    data: result,
-    isPending: isLoading,
-    sendAsync,
-    error,
-  } = useSendTransaction({});
+  const { isPending: isLoading, error } = sendTransactionInstance;
 
   // side effect for error logging
   useEffect(() => {
@@ -80,30 +75,26 @@ export const WriteOnlyFunctionForm = ({
   }, [error]);
 
   const handleWrite = async () => {
-    if (sendAsync) {
-      try {
-        const makeWriteWithParams = () =>
-          sendAsync(
-            !!contractInstance
-              ? [
-                  contractInstance.populate(
-                    abiFunction.name,
-                    getArgsAsStringInputFromForm(form),
-                  ),
-                ]
-              : [],
-          );
-        await writeTransaction(makeWriteWithParams);
-      } catch (e: any) {
-        const errorPattern = /Contract (.*?)"}/;
-        const match = errorPattern.exec(e.message);
-        const message = match ? match[1] : e.message;
+    try {
+      await writeTransaction(
+        !!contractInstance
+          ? [
+              contractInstance.populate(
+                abiFunction.name,
+                getArgsAsStringInputFromForm(form),
+              ),
+            ]
+          : [],
+      );
+    } catch (e: any) {
+      const errorPattern = /Contract (.*?)"}/;
+      const match = errorPattern.exec(e.message);
+      const message = match ? match[1] : e.message;
 
-        console.error(
-          "⚡️ ~ file: WriteOnlyFunctionForm.tsx:handleWrite ~ error",
-          message,
-        );
-      }
+      console.error(
+        "⚡️ ~ file: WriteOnlyFunctionForm.tsx:handleWrite ~ error",
+        message,
+      );
     }
   };
 

--- a/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
@@ -47,7 +47,7 @@ export const WriteOnlyFunctionForm = ({
     useState<FormErrorMessageState>({});
   const { status: walletStatus, isConnected, account, chainId } = useAccount();
   const { chain } = useNetwork();
-  const {writeTransaction, transactionReceiptInstance} = useTransactor();
+  const { writeTransaction, transactionReceiptInstance } = useTransactor();
   const { data: txResult } = transactionReceiptInstance;
   const { targetNetwork } = useTargetNetwork();
 

--- a/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
@@ -94,7 +94,6 @@ export const WriteOnlyFunctionForm = ({
               : [],
           );
         await writeTransaction(makeWriteWithParams);
-        onChange();
       } catch (e: any) {
         const errorPattern = /Contract (.*?)"}/;
         const match = errorPattern.exec(e.message);
@@ -115,7 +114,7 @@ export const WriteOnlyFunctionForm = ({
       txResult as unknown as InvokeTransactionReceiptResponse,
     );
     onChange();
-  }, [txResult]);
+  }, [txResult, onChange]);
 
   // TODO use `useMemo` to optimize also update in ReadOnlyFunctionForm
   const transformedFunction = transformAbiFunction(abiFunction);

--- a/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
@@ -16,7 +16,6 @@ import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";
 import {
   useSendTransaction,
   useNetwork,
-  useTransactionReceipt,
   useContract,
 } from "@starknet-react/core";
 import { Abi } from "abi-wan-kanabi";
@@ -48,7 +47,8 @@ export const WriteOnlyFunctionForm = ({
     useState<FormErrorMessageState>({});
   const { status: walletStatus, isConnected, account, chainId } = useAccount();
   const { chain } = useNetwork();
-  const writeTxn = useTransactor();
+  const {writeTransaction, transactionReceiptInstance} = useTransactor();
+  const { data: txResult } = transactionReceiptInstance;
   const { targetNetwork } = useTargetNetwork();
 
   const writeDisabled = useMemo(
@@ -93,7 +93,7 @@ export const WriteOnlyFunctionForm = ({
                 ]
               : [],
           );
-        await writeTxn(makeWriteWithParams);
+        await writeTransaction(makeWriteWithParams);
         onChange();
       } catch (e: any) {
         const errorPattern = /Contract (.*?)"}/;
@@ -110,9 +110,6 @@ export const WriteOnlyFunctionForm = ({
 
   const [displayedTxResult, setDisplayedTxResult] =
     useState<InvokeTransactionReceiptResponse>();
-  const { data: txResult } = useTransactionReceipt({
-    hash: result?.transaction_hash,
-  });
   useEffect(() => {
     setDisplayedTxResult(
       txResult as unknown as InvokeTransactionReceiptResponse,

--- a/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldMultiWriteContract.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldMultiWriteContract.test.ts
@@ -17,6 +17,20 @@ import { useDeployedContractInfo } from "~~/hooks/scaffold-stark";
 
 import { Contract, RpcProvider } from "starknet";
 
+// Mock the contracts object
+vi.mock("~~/utils/scaffold-stark/contract", () => ({
+  contracts: {
+    testNetwork: {
+      Strk: {
+        address: "0x12345",
+        abi: [{ type: "function", name: "transfer", inputs: [], outputs: [] }],
+      }
+    }
+  },
+  // Add any other exports that might be needed
+  ContractName: {},
+}));
+
 // Mock the external dependencies
 
 vi.mock("~~/hooks/scaffold-stark/useTargetNetwork", () => ({
@@ -35,7 +49,13 @@ vi.mock("starknet", () => {
   return {
     ...actualStarknet,
 
-    Contract: vi.fn(),
+    Contract: vi.fn().mockImplementation(() => ({
+      populate: vi.fn().mockReturnValue({
+        contractAddress: "0x123",
+        entrypoint: "transfer",
+        calldata: ["0x1234", "1000"],
+      }),
+    })),
 
     RpcProvider: vi.fn(),
   };
@@ -62,8 +82,8 @@ const useDeployedContractInfoMock = useDeployedContractInfo as Mock;
 const ContractMock = Contract as Mock;
 const useNetworkMock = useNetwork as Mock;
 
-// TODO: unskip (and rewrite if required) when we determine direction of this hook
-describe.skip("useScaffoldMultiWriteContract Hook", () => {
+// Using the test without skipping as it has been updated for the new structure
+describe("useScaffoldMultiWriteContract Hook", () => {
   const mockAbi = [
     { type: "function", name: "mockFunction", inputs: [], outputs: [] },
   ];
@@ -81,9 +101,20 @@ describe.skip("useScaffoldMultiWriteContract Hook", () => {
 
     useSendTransactionMock.mockReturnValue({
       sendAsync: mockSendTransaction,
+      status: "idle",
     });
 
-    useTransactorMock.mockReturnValue(mockTransactor);
+    useTransactorMock.mockReturnValue({
+      writeTransaction: vi.fn().mockResolvedValue("mock-tx-hash"),
+      sendTransactionInstance: {
+        sendAsync: vi.fn(),
+        status: "idle",
+      },
+      transactionReceiptInstance: {
+        data: null,
+        status: "idle",
+      },
+    });
 
     useDeployedContractInfoMock.mockReturnValue({
       data: {
@@ -97,6 +128,11 @@ describe.skip("useScaffoldMultiWriteContract Hook", () => {
       address: mockAddress,
 
       abi: mockAbi,
+      populate: vi.fn().mockReturnValue({
+        contractAddress: mockAddress,
+        entrypoint: "mockFunction",
+        calldata: [],
+      }),
     }));
   });
 
@@ -135,121 +171,17 @@ describe.skip("useScaffoldMultiWriteContract Hook", () => {
       }),
     );
 
+    let error;
     await act(async () => {
-      await result.current.sendAsync();
+      try {
+        await result.current.sendAsync();
+      } catch (e) {
+        error = e;
+      }
     });
 
-    vi.spyOn(result.current, "sendAsync").mockRejectedValue(
-      new Error("Please connect your wallet"),
-    );
-
-    await expect(result.current.sendAsync).rejects.toThrowError(
-      "Please connect your wallet",
-    );
-  });
-
-  it("should handle wrong network", async () => {
-    useNetworkMock.mockReturnValueOnce({ chain: { id: 2 } });
-
-    const { result } = renderHook(() =>
-      useScaffoldMultiWriteContract({
-        calls: [
-          {
-            contractName: "Strk",
-            functionName: "transfer",
-            args: ["arg1", 1],
-          },
-        ],
-      }),
-    );
-
-    await act(async () => {
-      await result.current.sendAsync();
-    });
-
-    vi.spyOn(result.current, "sendAsync").mockRejectedValue(
-      new Error("You are on the wrong network"),
-    );
-
-    await expect(result.current.sendAsync).rejects.toThrowError(
-      "You are on the wrong network",
-    );
-  });
-
-  it("should show error if contract ABI is missing", async () => {
-    const { result } = renderHook(() =>
-      useScaffoldMultiWriteContract({
-        calls: [
-          {
-            contractName: "Strk",
-            functionName: "transfer",
-            args: ["arg1", 1],
-          },
-        ],
-      }),
-    );
-
-    await act(async () => {
-      await result.current.sendAsync();
-    });
-
-    vi.spyOn(result.current, "sendAsync").mockRejectedValue(
-      new Error("Function myFunction not found in contract ABI"),
-    );
-
-    await expect(result.current.sendAsync).rejects.toThrowError(
-      "Function myFunction not found in contract ABI",
-    );
-  });
-
-  it("should send contract write transaction", async () => {
-    useTransactorMock.mockReturnValue((fn: any) => fn());
-
-    const { result } = renderHook(() =>
-      useScaffoldMultiWriteContract({
-        calls: [
-          {
-            contractName: "Strk",
-            functionName: "transfer",
-            args: ["arg1", 1],
-          },
-        ],
-      }),
-    );
-
-    await act(async () => {
-      await result.current.sendAsync();
-    });
-
-    expect(mockSendTransaction).toHaveBeenCalled();
-  });
-
-  it("should show error notification if sendAsync is not available", async () => {
-    useSendTransactionMock.mockReturnValueOnce({ sendAsync: null });
-
-    const { result } = renderHook(() =>
-      useScaffoldMultiWriteContract({
-        calls: [
-          {
-            contractName: "Strk",
-            functionName: "transfer",
-            args: ["arg1", 1],
-          },
-        ],
-      }),
-    );
-
-    await act(async () => {
-      await result.current.sendAsync();
-    });
-
-    vi.spyOn(result.current, "sendAsync").mockRejectedValue(
-      new Error("Contract writer error. Try again."),
-    );
-
-    await expect(result.current.sendAsync).rejects.toThrowError(
-      "Contract writer error. Try again.",
-    );
+    expect(error).toBeUndefined(); // We just log to console in this case
+    expect(useTransactorMock().writeTransaction).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldMultiWriteContract.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldMultiWriteContract.test.ts
@@ -24,8 +24,8 @@ vi.mock("~~/utils/scaffold-stark/contract", () => ({
       Strk: {
         address: "0x12345",
         abi: [{ type: "function", name: "transfer", inputs: [], outputs: [] }],
-      }
-    }
+      },
+    },
   },
   // Add any other exports that might be needed
   ContractName: {},

--- a/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldWriteContract.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldWriteContract.test.ts
@@ -52,25 +52,25 @@ describe("useScaffoldWriteContract", () => {
   beforeEach(() => {
     // Reset all mocks before each test
     vi.clearAllMocks();
-    
+
     // Set up the mock implementations for the hooks
-    mockUseSendTransaction.mockReturnValue({ 
+    mockUseSendTransaction.mockReturnValue({
       sendAsync: vi.fn(),
-      status: "idle" 
+      status: "idle",
     });
-    
+
     mockUseTransactor.mockReturnValue({
       writeTransaction: vi.fn().mockResolvedValue("mock-tx-hash"),
-      sendTransactionInstance: { 
+      sendTransactionInstance: {
         sendAsync: vi.fn(),
-        status: "idle" 
+        status: "idle",
       },
       transactionReceiptInstance: {
         data: null,
-        status: "idle"
-      }
+        status: "idle",
+      },
     });
-    
+
     mockUseTargetNetwork.mockReturnValue({
       targetNetwork: { id: 1, network: "testnet" },
     });
@@ -105,7 +105,7 @@ describe("useScaffoldWriteContract", () => {
         abi: [{ name: "testFunction" }],
       },
     });
-    
+
     mockUseTargetNetwork.mockReturnValue({
       targetNetwork: { id: 2, network: "mainnet" }, // Different network ID
     });
@@ -151,7 +151,7 @@ describe("useScaffoldWriteContract", () => {
           contractAddress: "0x123",
           entrypoint: functionName,
         }),
-      ])
+      ]),
     );
   });
 

--- a/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldWriteContract.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldWriteContract.test.ts
@@ -9,6 +9,19 @@ import { useSendTransaction } from "@starknet-react/core";
 import { vi, describe, beforeEach, afterAll, it, expect } from "vitest";
 import { Mock } from "vitest";
 
+// Mock starknet Contract constructor
+vi.mock("starknet", () => {
+  return {
+    Contract: vi.fn().mockImplementation(() => ({
+      populate: vi.fn().mockReturnValue({
+        contractAddress: "0x123",
+        entrypoint: "transfer",
+        calldata: ["0x1234", "1000"],
+      }),
+    })),
+  };
+});
+
 // Mock dependencies
 vi.mock("~~/hooks/scaffold-stark", () => ({
   useDeployedContractInfo: vi.fn(),
@@ -24,21 +37,43 @@ vi.mock("@starknet-react/core", () => ({
   useNetwork: vi.fn().mockReturnValue({ chain: { id: 1 } }),
 }));
 
-// TODO: unskip (and rewrite if required) when we determine direction of this hook
-describe.skip("useScaffoldWriteContract", () => {
+// Now using the test without skipping as it has been updated for the new structure
+describe("useScaffoldWriteContract", () => {
   const contractName = "Strk";
   const functionName = "transfer";
   const args: readonly [string, number] = ["0x1234", 1000];
 
   const mockUseDeployedContractInfo =
     useDeployedContractInfo as unknown as Mock;
-  const mochUseSendTransaction = useSendTransaction as unknown as Mock;
+  const mockUseSendTransaction = useSendTransaction as unknown as Mock;
   const mockUseTransactor = useTransactor as unknown as Mock;
   const mockUseTargetNetwork = useTargetNetwork as unknown as Mock;
 
   beforeEach(() => {
     // Reset all mocks before each test
     vi.clearAllMocks();
+    
+    // Set up the mock implementations for the hooks
+    mockUseSendTransaction.mockReturnValue({ 
+      sendAsync: vi.fn(),
+      status: "idle" 
+    });
+    
+    mockUseTransactor.mockReturnValue({
+      writeTransaction: vi.fn().mockResolvedValue("mock-tx-hash"),
+      sendTransactionInstance: { 
+        sendAsync: vi.fn(),
+        status: "idle" 
+      },
+      transactionReceiptInstance: {
+        data: null,
+        status: "idle"
+      }
+    });
+    
+    mockUseTargetNetwork.mockReturnValue({
+      targetNetwork: { id: 1, network: "testnet" },
+    });
   });
 
   afterAll(() => {
@@ -47,12 +82,6 @@ describe.skip("useScaffoldWriteContract", () => {
 
   it("should handle case where contract is not deployed", async () => {
     mockUseDeployedContractInfo.mockReturnValue({ data: undefined });
-    const mockSendTransaction = { sendAsync: vi.fn() };
-    mochUseSendTransaction.mockReturnValue(mockSendTransaction);
-    mockUseTransactor.mockReturnValue(vi.fn());
-    mockUseTargetNetwork.mockReturnValue({
-      targetNetwork: { id: 1 },
-    });
 
     const { result } = renderHook(() =>
       useScaffoldWriteContract({
@@ -66,7 +95,7 @@ describe.skip("useScaffoldWriteContract", () => {
       await result.current.sendAsync();
     });
 
-    expect(mockSendTransaction.sendAsync).not.toHaveBeenCalled();
+    expect(mockUseTransactor().writeTransaction).not.toHaveBeenCalled();
   });
 
   it("should handle case where user is on the wrong network", async () => {
@@ -76,11 +105,9 @@ describe.skip("useScaffoldWriteContract", () => {
         abi: [{ name: "testFunction" }],
       },
     });
-    const mockSendTransaction = { sendAsync: vi.fn() };
-    mochUseSendTransaction.mockReturnValue(mockSendTransaction);
-    mockUseTransactor.mockReturnValue(vi.fn());
+    
     mockUseTargetNetwork.mockReturnValue({
-      targetNetwork: { id: 2 }, // Different network ID
+      targetNetwork: { id: 2, network: "mainnet" }, // Different network ID
     });
 
     const { result } = renderHook(() =>
@@ -95,7 +122,7 @@ describe.skip("useScaffoldWriteContract", () => {
       await result.current.sendAsync();
     });
 
-    expect(mockSendTransaction.sendAsync).not.toHaveBeenCalled();
+    expect(mockUseTransactor().writeTransaction).not.toHaveBeenCalled();
   });
 
   it("should send transaction when contract is deployed and user is on correct network", async () => {
@@ -105,12 +132,6 @@ describe.skip("useScaffoldWriteContract", () => {
         abi: [{ name: "testFunction" }],
       },
     });
-    const mockSendTransaction = { sendAsync: vi.fn() };
-    mochUseSendTransaction.mockReturnValue(mockSendTransaction);
-    mockUseTransactor.mockReturnValue(vi.fn((fn) => fn()));
-    mockUseTargetNetwork.mockReturnValue({
-      targetNetwork: { id: 1 },
-    });
 
     const { result } = renderHook(() =>
       useScaffoldWriteContract({
@@ -124,13 +145,14 @@ describe.skip("useScaffoldWriteContract", () => {
       await result.current.sendAsync();
     });
 
-    expect(mockSendTransaction.sendAsync).toHaveBeenCalledWith([
-      {
-        contractAddress: "0x123",
-        entrypoint: functionName,
-        calldata: expect.any(Array),
-      },
-    ]);
+    expect(mockUseTransactor().writeTransaction).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          contractAddress: "0x123",
+          entrypoint: functionName,
+        }),
+      ])
+    );
   });
 
   it("should call useDeployedContractInfo with the correct contract name", () => {

--- a/packages/nextjs/hooks/scaffold-stark/__tests__/useTransactor.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/useTransactor.test.ts
@@ -1,11 +1,23 @@
 import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
-import { renderHook, act, render } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { useTransactor } from "../useTransactor";
 import { useAccount } from "~~/hooks/useAccount";
 import { useTargetNetwork } from "../useTargetNetwork";
 import { notification } from "~~/utils/scaffold-stark";
 import { AccountInterface } from "starknet";
 import { getBlockExplorerTxLink } from "~~/utils/scaffold-stark";
+
+// Mock the @starknet-react/core hooks
+const sendAsyncMock = vi.fn().mockResolvedValue({ transaction_hash: "mock-tx-hash" });
+vi.mock("@starknet-react/core", () => ({
+  useSendTransaction: () => ({
+    sendAsync: sendAsyncMock,
+  }),
+  useTransactionReceipt: () => ({
+    data: { receipt: { status: "ACCEPTED_ON_L1" } },
+    status: "success",
+  }),
+}));
 
 vi.mock("~~/utils/scaffold-stark", () => ({
   notification: {
@@ -53,6 +65,10 @@ describe("useTransactor", () => {
       targetNetwork: { network: "mock-network" },
     });
 
+    // Reset the sendAsyncMock for each test
+    sendAsyncMock.mockClear();
+    sendAsyncMock.mockResolvedValue({ transaction_hash: "mock-tx-hash" });
+
     vi.clearAllMocks();
   });
 
@@ -61,37 +77,16 @@ describe("useTransactor", () => {
       useTransactor(walletClientMock as AccountInterface),
     );
 
+    const mockTx = [{ contractAddress: "0x123", entrypoint: "test", calldata: [] }];
+
     await act(async () => {
-      const response = await result.current(() =>
-        Promise.resolve("mock-tx-hash"),
-      );
+      const response = await result.current.writeTransaction(mockTx);
       expect(response).toBe("mock-tx-hash");
     });
 
-    expect(notification.loading).toHaveBeenCalledWith(
-      expect.objectContaining({
-        props: { message: "Awaiting for user confirmation" },
-      }),
-    );
-
-    expect(notification.success).toHaveBeenCalledWith(expect.any(Object), {
-      icon: "🎉",
-    });
-
-    const successNotificationCall = (
-      notification.success as ReturnType<typeof vi.fn>
-    ).mock.calls[0][0];
-    const { container } = render(successNotificationCall);
-
-    // Verify message content
-    const messageElement = container.querySelector("p");
-    expect(messageElement?.textContent).toBe(
-      "Transaction completed successfully!",
-    );
-
-    const linkElement = container.querySelector("a");
-    expect(linkElement?.getAttribute("href")).toBe("mock-block-explorer-link");
-    expect(linkElement?.textContent).toBe("check out transaction");
+    expect(notification.loading).toHaveBeenCalled();
+    expect(notification.remove).toHaveBeenCalled();
+    expect(sendAsyncMock).toHaveBeenCalledWith(mockTx);
   });
 
   it("should show error notification when wallet client is unavailable", async () => {
@@ -99,10 +94,10 @@ describe("useTransactor", () => {
 
     const { result } = renderHook(() => useTransactor());
 
+    const mockTx = [{ contractAddress: "0x123", entrypoint: "test", calldata: [] }];
+
     await act(async () => {
-      const response = await result.current(() =>
-        Promise.resolve({ transaction_hash: "mock-tx-hash" }),
-      );
+      const response = await result.current.writeTransaction(mockTx);
       expect(response).toBeUndefined();
     });
 
@@ -111,14 +106,17 @@ describe("useTransactor", () => {
 
   it("should handle transaction failure", async () => {
     const mockError = new Error("Contract mock-error");
-    const mockTransaction = vi.fn().mockRejectedValue(mockError);
+    sendAsyncMock.mockRejectedValueOnce(mockError);
+    
     const { result } = renderHook(() =>
       useTransactor(walletClientMock as AccountInterface),
     );
 
-    await expect(result.current(mockTransaction)).rejects.toThrow(mockError);
+    const mockTx = [{ contractAddress: "0x123", entrypoint: "test", calldata: [] }];
 
-    expect(notification.error).toHaveBeenCalledWith("Contract mock-error");
+    await expect(result.current.writeTransaction(mockTx)).rejects.toThrow(mockError);
+
+    expect(notification.error).toHaveBeenCalled();
   });
 
   it("should execute the transaction and return the transaction hash", async () => {
@@ -126,60 +124,50 @@ describe("useTransactor", () => {
       useTransactor(walletClientMock as AccountInterface),
     );
 
-    const mockTx = vi
-      .fn()
-      .mockResolvedValue({ transaction_hash: "mock-tx-hash" });
+    const mockTx = [{ contractAddress: "0x123", entrypoint: "test", calldata: [] }];
 
     await act(async () => {
-      const transactionHash = await result.current(mockTx);
+      const transactionHash = await result.current.writeTransaction(mockTx);
       expect(transactionHash).toBe("mock-tx-hash");
     });
   });
 
-  it("should set blockExplorerTxURL to an empty string if networkId is falsy", async () => {
-    const mockGetChainId = vi.fn().mockResolvedValue(null);
-    (walletClientMock as any).getChainId = mockGetChainId;
-
-    (getBlockExplorerTxLink as Mock).mockReturnValue("");
-
+  it("should set blockExplorerTxURL correctly", async () => {
     const { result } = renderHook(() =>
       useTransactor(walletClientMock as AccountInterface),
     );
 
-    const mockTx = vi
-      .fn()
-      .mockResolvedValue({ transaction_hash: "mock-tx-hash" });
+    const mockTx = [{ contractAddress: "0x123", entrypoint: "test", calldata: [] }];
 
     await act(async () => {
-      const transactionHash = await result.current(mockTx);
+      const transactionHash = await result.current.writeTransaction(mockTx);
       expect(transactionHash).toBe("mock-tx-hash");
     });
 
-    expect(getBlockExplorerTxLink).not.toHaveBeenCalled();
-
-    const blockExplorerTxURL = mockGetChainId()
-      ? getBlockExplorerTxLink("mock-network", "mock-tx-hash")
-      : "";
-    expect(blockExplorerTxURL).toBe("");
+    expect(getBlockExplorerTxLink).toHaveBeenCalledWith("mock-network", "mock-tx-hash");
   });
 
   it("should handle string transaction results", async () => {
-    const mockTransaction = vi.fn().mockResolvedValue("mock-tx-hash");
+    sendAsyncMock.mockResolvedValueOnce("mock-tx-hash");
+    
     const { result } = renderHook(() =>
       useTransactor(walletClientMock as AccountInterface),
     );
 
-    const txHash = await result.current(mockTransaction);
+    const mockTx = [{ contractAddress: "0x123", entrypoint: "test", calldata: [] }];
 
-    expect(txHash).toBe("mock-tx-hash");
+    await act(async () => {
+      const txHash = await result.current.writeTransaction(mockTx);
+      expect(txHash).toBe("mock-tx-hash");
+    });
   });
 
-  it("should handle missing transaction function", async () => {
+  it("should handle missing transaction", async () => {
     const { result } = renderHook(() =>
       useTransactor(walletClientMock as AccountInterface),
     );
 
-    await expect(result.current(undefined as any)).rejects.toThrow(
+    await expect(result.current.writeTransaction(null as any)).rejects.toThrow(
       "Incorrect transaction passed to transactor",
     );
   });

--- a/packages/nextjs/hooks/scaffold-stark/__tests__/useTransactor.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/useTransactor.test.ts
@@ -8,7 +8,9 @@ import { AccountInterface } from "starknet";
 import { getBlockExplorerTxLink } from "~~/utils/scaffold-stark";
 
 // Mock the @starknet-react/core hooks
-const sendAsyncMock = vi.fn().mockResolvedValue({ transaction_hash: "mock-tx-hash" });
+const sendAsyncMock = vi
+  .fn()
+  .mockResolvedValue({ transaction_hash: "mock-tx-hash" });
 vi.mock("@starknet-react/core", () => ({
   useSendTransaction: () => ({
     sendAsync: sendAsyncMock,
@@ -77,7 +79,9 @@ describe("useTransactor", () => {
       useTransactor(walletClientMock as AccountInterface),
     );
 
-    const mockTx = [{ contractAddress: "0x123", entrypoint: "test", calldata: [] }];
+    const mockTx = [
+      { contractAddress: "0x123", entrypoint: "test", calldata: [] },
+    ];
 
     await act(async () => {
       const response = await result.current.writeTransaction(mockTx);
@@ -94,7 +98,9 @@ describe("useTransactor", () => {
 
     const { result } = renderHook(() => useTransactor());
 
-    const mockTx = [{ contractAddress: "0x123", entrypoint: "test", calldata: [] }];
+    const mockTx = [
+      { contractAddress: "0x123", entrypoint: "test", calldata: [] },
+    ];
 
     await act(async () => {
       const response = await result.current.writeTransaction(mockTx);
@@ -107,14 +113,18 @@ describe("useTransactor", () => {
   it("should handle transaction failure", async () => {
     const mockError = new Error("Contract mock-error");
     sendAsyncMock.mockRejectedValueOnce(mockError);
-    
+
     const { result } = renderHook(() =>
       useTransactor(walletClientMock as AccountInterface),
     );
 
-    const mockTx = [{ contractAddress: "0x123", entrypoint: "test", calldata: [] }];
+    const mockTx = [
+      { contractAddress: "0x123", entrypoint: "test", calldata: [] },
+    ];
 
-    await expect(result.current.writeTransaction(mockTx)).rejects.toThrow(mockError);
+    await expect(result.current.writeTransaction(mockTx)).rejects.toThrow(
+      mockError,
+    );
 
     expect(notification.error).toHaveBeenCalled();
   });
@@ -124,7 +134,9 @@ describe("useTransactor", () => {
       useTransactor(walletClientMock as AccountInterface),
     );
 
-    const mockTx = [{ contractAddress: "0x123", entrypoint: "test", calldata: [] }];
+    const mockTx = [
+      { contractAddress: "0x123", entrypoint: "test", calldata: [] },
+    ];
 
     await act(async () => {
       const transactionHash = await result.current.writeTransaction(mockTx);
@@ -137,24 +149,31 @@ describe("useTransactor", () => {
       useTransactor(walletClientMock as AccountInterface),
     );
 
-    const mockTx = [{ contractAddress: "0x123", entrypoint: "test", calldata: [] }];
+    const mockTx = [
+      { contractAddress: "0x123", entrypoint: "test", calldata: [] },
+    ];
 
     await act(async () => {
       const transactionHash = await result.current.writeTransaction(mockTx);
       expect(transactionHash).toBe("mock-tx-hash");
     });
 
-    expect(getBlockExplorerTxLink).toHaveBeenCalledWith("mock-network", "mock-tx-hash");
+    expect(getBlockExplorerTxLink).toHaveBeenCalledWith(
+      "mock-network",
+      "mock-tx-hash",
+    );
   });
 
   it("should handle string transaction results", async () => {
     sendAsyncMock.mockResolvedValueOnce("mock-tx-hash");
-    
+
     const { result } = renderHook(() =>
       useTransactor(walletClientMock as AccountInterface),
     );
 
-    const mockTx = [{ contractAddress: "0x123", entrypoint: "test", calldata: [] }];
+    const mockTx = [
+      { contractAddress: "0x123", entrypoint: "test", calldata: [] },
+    ];
 
     await act(async () => {
       const txHash = await result.current.writeTransaction(mockTx);

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
@@ -83,13 +83,10 @@ export const useScaffoldMultiWriteContract = <
         }
       })();
 
-      // setIsMining(true);
       return await sendTxnWrapper(parsedCalls);
     } catch (e: any) {
       throw e;
-    } finally {
-      // setIsMining(false);
-    }
+    } 
   };
 
   return {

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
@@ -39,11 +39,8 @@ export const useScaffoldMultiWriteContract = <
 }) => {
   const { targetNetwork } = useTargetNetwork();
   const { chain } = useNetwork();
-  const { writeTransaction: sendTxnWrapper } = useTransactor();
-
-  // TODO add custom options
-
-  const sendTransactionInstance = useSendTransaction({});
+  const { writeTransaction: sendTxnWrapper, sendTransactionInstance } =
+    useTransactor();
 
   const sendContractWriteTx = async () => {
     if (!chain?.id) {
@@ -55,50 +52,43 @@ export const useScaffoldMultiWriteContract = <
       return;
     }
 
-    if (sendTransactionInstance.sendAsync) {
-      try {
-        // we just parse calldata here so that it will only parse on demand.
-        // use IIFE pattern
-        const parsedCalls = (() => {
-          if (calls) {
-            return calls.map((call) => {
-              if (isRawCall(call)) {
-                return call;
-              }
-              const functionName = call.functionName;
-              const contractName = call.contractName;
-              const unParsedArgs = call.args as any[];
-              const contract = contracts?.[targetNetwork.network]?.[
-                contractName as ContractName
-              ] as Contract<TContractName>;
-              // we convert to starknetjs contract instance here since deployed data may be undefined if contract is not deployed
-              const contractInstance = new StarknetJsContract(
-                contract.abi,
-                contract.address,
-              );
+    try {
+      // we just parse calldata here so that it will only parse on demand.
+      // use IIFE pattern
+      const parsedCalls = (() => {
+        if (calls) {
+          return calls.map((call) => {
+            if (isRawCall(call)) {
+              return call;
+            }
+            const functionName = call.functionName;
+            const contractName = call.contractName;
+            const unParsedArgs = call.args as any[];
+            const contract = contracts?.[targetNetwork.network]?.[
+              contractName as ContractName
+            ] as Contract<TContractName>;
+            // we convert to starknetjs contract instance here since deployed data may be undefined if contract is not deployed
+            const contractInstance = new StarknetJsContract(
+              contract.abi,
+              contract.address,
+            );
 
-              return contractInstance.populate(
-                functionName,
-                unParsedArgs as any[],
-              );
-            });
-          } else {
-            return [];
-          }
-        })();
+            return contractInstance.populate(
+              functionName,
+              unParsedArgs as any[],
+            );
+          });
+        } else {
+          return [];
+        }
+      })();
 
-        // setIsMining(true);
-        return await sendTxnWrapper(() =>
-          sendTransactionInstance.sendAsync(parsedCalls),
-        );
-      } catch (e: any) {
-        throw e;
-      } finally {
-        // setIsMining(false);
-      }
-    } else {
-      notification.error("Contract writer error. Try again.");
-      return;
+      // setIsMining(true);
+      return await sendTxnWrapper(parsedCalls);
+    } catch (e: any) {
+      throw e;
+    } finally {
+      // setIsMining(false);
     }
   };
 

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
@@ -39,7 +39,7 @@ export const useScaffoldMultiWriteContract = <
 }) => {
   const { targetNetwork } = useTargetNetwork();
   const { chain } = useNetwork();
-  const sendTxnWrapper = useTransactor();
+  const { writeTransaction: sendTxnWrapper } = useTransactor();
 
   // TODO add custom options
 

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
@@ -28,11 +28,9 @@ export const useScaffoldWriteContract = <
 }: UseScaffoldWriteConfig<TAbi, TContractName, TFunctionName>) => {
   const { data: deployedContractData } = useDeployedContractInfo(contractName);
   const { chain } = useNetwork();
-  const { writeTransaction: sendTxnWrapper } = useTransactor();
+  const { writeTransaction: sendTxnWrapper, sendTransactionInstance } =
+    useTransactor();
   const { targetNetwork } = useTargetNetwork();
-
-  // leave blank for now since default args will be called by the trigger function anyway
-  const sendTransactionInstance = useSendTransaction({});
 
   const sendContractWriteTx = useCallback(
     async (params?: {
@@ -69,20 +67,13 @@ export const useScaffoldWriteContract = <
         ? [contractInstance.populate(functionName, newArgs as any[])]
         : [];
 
-      if (sendTransactionInstance.sendAsync) {
-        try {
-          // setIsMining(true);
-          return await sendTxnWrapper(() =>
-            sendTransactionInstance.sendAsync(newCalls as any[]),
-          );
-        } catch (e: any) {
-          throw e;
-        } finally {
-          // setIsMining(false);
-        }
-      } else {
-        notification.error("Contract writer error. Try again.");
-        return;
+      try {
+        // setIsMining(true);
+        return await sendTxnWrapper(newCalls as any[]);
+      } catch (e: any) {
+        throw e;
+      } finally {
+        // setIsMining(false);
       }
     },
     [

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
@@ -28,7 +28,7 @@ export const useScaffoldWriteContract = <
 }: UseScaffoldWriteConfig<TAbi, TContractName, TFunctionName>) => {
   const { data: deployedContractData } = useDeployedContractInfo(contractName);
   const { chain } = useNetwork();
-  const sendTxnWrapper = useTransactor();
+  const { writeTransaction: sendTxnWrapper } = useTransactor();
   const { targetNetwork } = useTargetNetwork();
 
   // leave blank for now since default args will be called by the trigger function anyway

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
@@ -68,13 +68,10 @@ export const useScaffoldWriteContract = <
         : [];
 
       try {
-        // setIsMining(true);
         return await sendTxnWrapper(newCalls as any[]);
       } catch (e: any) {
         throw e;
-      } finally {
-        // setIsMining(false);
-      }
+      } 
     },
     [
       args,

--- a/packages/nextjs/hooks/scaffold-stark/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-stark/useTransactor.tsx
@@ -18,7 +18,6 @@ import {
 type TransactionFunc = (
   tx: Call[],
   withSendTransaction?: boolean,
-  // | SendTransactionParameters,
 ) => Promise<string | undefined>;
 
 interface UseTransactorReturn {

--- a/packages/nextjs/hooks/scaffold-stark/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-stark/useTransactor.tsx
@@ -13,8 +13,11 @@ import {
   UseTransactionReceiptResult,
 } from "@starknet-react/core";
 
+type CustomTransactionFunc = () =>
+  | Promise<InvokeFunctionResponse>
+  | Promise<string>;
 type TransactionFunc = (
-  tx: () => Promise<InvokeFunctionResponse> | Promise<string>,
+  tx: CustomTransactionFunc | Call[],
   // | SendTransactionParameters,
 ) => Promise<string | undefined>;
 
@@ -101,7 +104,7 @@ export const useTransactor = (
   }, [txResult]);
 
   const writeTransaction = async (
-    tx: () => Promise<InvokeFunctionResponse> | Promise<string>,
+    tx: CustomTransactionFunc | Call[],
   ): Promise<string | undefined> => {
     if (!walletClient) {
       notification.error("Cannot access account");

--- a/packages/nextjs/hooks/scaffold-stark/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-stark/useTransactor.tsx
@@ -8,7 +8,10 @@ import {
 import { getBlockExplorerTxLink, notification } from "~~/utils/scaffold-stark";
 import { useTargetNetwork } from "./useTargetNetwork";
 import { useState, useEffect } from "react";
-import { useTransactionReceipt, UseTransactionReceiptResult } from "@starknet-react/core";
+import {
+  useTransactionReceipt,
+  UseTransactionReceiptResult,
+} from "@starknet-react/core";
 
 type TransactionFunc = (
   tx: () => Promise<InvokeFunctionResponse> | Promise<string>,
@@ -63,9 +66,9 @@ export const useTransactor = (
   }
 
   const [notificationId, setNotificationId] = useState<string | null>(null);
-  const [blockExplorerTxURL, setBlockExplorerTxURL] = useState<string | undefined>(
-    undefined,
-  );
+  const [blockExplorerTxURL, setBlockExplorerTxURL] = useState<
+    string | undefined
+  >(undefined);
   const [transactionHash, setTransactionHash] = useState<string | undefined>(
     undefined,
   );
@@ -97,7 +100,9 @@ export const useTransactor = (
     }
   }, [txResult]);
 
-  const writeTransaction = async (tx: () => Promise<InvokeFunctionResponse> | Promise<string>): Promise<string | undefined> => {
+  const writeTransaction = async (
+    tx: () => Promise<InvokeFunctionResponse> | Promise<string>,
+  ): Promise<string | undefined> => {
     if (!walletClient) {
       notification.error("Cannot access account");
       console.error("⚡️ ~ file: useTransactor.tsx ~ error");
@@ -189,7 +194,7 @@ export const useTransactor = (
         <TxnNotification
           message="Waiting for transaction to complete."
           blockExplorerLink={blockExplorerTxURL}
-        />
+        />,
       );
       setNotificationId(notificationId);
     } catch (error: any) {
@@ -212,6 +217,6 @@ export const useTransactor = (
 
   return {
     writeTransaction,
-    transactionReceiptInstance
-  }
+    transactionReceiptInstance,
+  };
 };

--- a/packages/nextjs/hooks/scaffold-stark/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-stark/useTransactor.tsx
@@ -9,21 +9,21 @@ import { getBlockExplorerTxLink, notification } from "~~/utils/scaffold-stark";
 import { useTargetNetwork } from "./useTargetNetwork";
 import { useState, useEffect } from "react";
 import {
+  useSendTransaction,
+  UseSendTransactionResult,
   useTransactionReceipt,
   UseTransactionReceiptResult,
 } from "@starknet-react/core";
 
-type CustomTransactionFunc = () =>
-  | Promise<InvokeFunctionResponse>
-  | Promise<string>;
 type TransactionFunc = (
-  tx: CustomTransactionFunc | Call[],
+  tx: Call[],
   // | SendTransactionParameters,
 ) => Promise<string | undefined>;
 
 interface UseTransactorReturn {
   writeTransaction: TransactionFunc;
   transactionReceiptInstance: UseTransactionReceiptResult;
+  sendTransactionInstance: UseSendTransactionResult;
 }
 
 /**
@@ -67,6 +67,7 @@ export const useTransactor = (
   if (walletClient === undefined && account) {
     walletClient = account;
   }
+  const sendTransactionInstance = useSendTransaction({});
 
   const [notificationId, setNotificationId] = useState<string | null>(null);
   const [blockExplorerTxURL, setBlockExplorerTxURL] = useState<
@@ -103,9 +104,8 @@ export const useTransactor = (
     }
   }, [txResult]);
 
-  const writeTransaction = async (
-    tx: CustomTransactionFunc | Call[],
-  ): Promise<string | undefined> => {
+  const writeTransaction = async (tx: Call[]): Promise<string | undefined> => {
+    resetStates();
     if (!walletClient) {
       notification.error("Cannot access account");
       console.error("⚡️ ~ file: useTransactor.tsx ~ error");
@@ -121,64 +121,13 @@ export const useTransactor = (
       notificationId = notification.loading(
         <TxnNotification message="Awaiting for user confirmation" />,
       );
-      if (typeof tx === "function") {
+      if (tx != null) {
         // Tx is already prepared by the caller
-        const result = await tx();
+        const result = await sendTransactionInstance.sendAsync(tx);
         if (typeof result === "string") {
           transactionHash = result;
         } else {
           transactionHash = result.transaction_hash;
-        }
-      } else if (tx != null) {
-        try {
-          // First try to estimate fees
-          const estimatedFee = await walletClient.estimateInvokeFee(
-            tx as Call[],
-          );
-
-          // Use estimated fee with a safety margin (multiply by 1.5)
-          const maxFee =
-            (BigInt(estimatedFee.overall_fee) * BigInt(15)) / BigInt(10);
-
-          // Set RPC 0.8 compatible parameters with estimated fees
-          const txOptions = {
-            version: constants.TRANSACTION_VERSION.V3,
-            maxFee: "0x" + maxFee.toString(16),
-          };
-
-          transactionHash = (await walletClient.execute(tx, txOptions))
-            .transaction_hash;
-        } catch (feeEstimationError) {
-          console.warn(
-            "Fee estimation failed, using fallback values:",
-            feeEstimationError,
-          );
-
-          // Fallback to safe default values if estimation fails
-          const txOptions = {
-            version: constants.TRANSACTION_VERSION.V3,
-            // Use a reasonable maxFee value that won't exceed account balance
-            maxFee: "0x1000000000",
-            // Set resource bounds for RPC 0.8 compatibility
-            resourceBounds: {
-              l1_gas: {
-                max_amount: "0x1000000",
-                max_price_per_unit: "0x1",
-              },
-              l2_gas: {
-                max_amount: "0x1000000",
-                max_price_per_unit: "0x1",
-              },
-            },
-            // Add l1_data_gas field for RPC 0.8 compatibility
-            l1_data_gas: {
-              max_amount: "0x1000000",
-              max_price_per_unit: "0x1",
-            },
-          };
-
-          transactionHash = (await walletClient.execute(tx, txOptions))
-            .transaction_hash;
         }
       } else {
         throw new Error("Incorrect transaction passed to transactor");
@@ -221,5 +170,6 @@ export const useTransactor = (
   return {
     writeTransaction,
     transactionReceiptInstance,
+    sendTransactionInstance,
   };
 };


### PR DESCRIPTION
# Fix: Fast Reload not working on testnet mode

Fixes #493

## Types of change

- [ ] Feature
- [X] Bug
- [X] Enhancement

## Changes:
- Reload states after transaction is complete
- Correct notification flow

## Critical Changes:
**useTransactor behavior:**
  - Center sending transaction logic into this hook, no need to create other `useSendTransaction` and `useTransactionReceip`t hooks seperately
  - Automatically handle transaction status and push correct notification
  - return `writeTransaction`, `transactionReceiptInstance`, `sendTransactionInstance` instead of only writeTransaction

**writeTransaction behavior:**
  - `writeTransaction` now only accept Call[] parameter
  - `writeTransaction` can take optional parameter `withSendTransaction = false` to use manually send transaction with fallback, otherwise it will use sendTransaction hook as default