### PR TITLE
chore: remove console log error when api fail

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldStarkProfile.tsx
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldStarkProfile.tsx
@@ -58,7 +58,6 @@ export const fetchProfileFromApi = async (address: string) => {
       // proofOfPersonhood?: boolean;
     };
   } catch (e) {
-    console.error(e);
     return {
       name: "",
       profilePicture: "",


### PR DESCRIPTION
# Task name here

Fixes #487

## Types of change

- [x] Bug

## Comments (optional)

- When the Starknet API cannot find data for a given address, it returns a 400 Bad Request with a message like “No data found for the given address.” This is expected behavior and not necessarily an error.

- In this PR, I’ve removed the explicit error handling that previously resulted in noisy logs. Please note that browser developer tools (e.g. Chrome DevTools) may still display a network error for the failed request — this is outside of our control.
