### PR TITLE
Bao/add ci for e2e tests

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,0 +1,28 @@
+name: Run E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run docker compose
+        uses: hoverkraft-tech/compose-action@v2.0.1
+        with:
+          compose-file: "./ui-automation/docker-compose.yml"
+          up-flags: "--build -d"
+
+      - name: Wait for services and run tests
+        run: |
+          chmod +x ./ui-automation/start.sh
+          ./ui-automation/start.sh

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  run-e2e-tests:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -25,4 +25,4 @@ jobs:
       - name: Wait for services and run tests
         run: |
           chmod +x ./ui-automation/start.sh
-          ./ui-automation/start.sh
+          ./ui-automation/start.sh --ci

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "workspaces": {
     "packages": [
+      "ui-automation",
       "packages/snfoundry",
       "packages/nextjs"
     ]

--- a/ui-automation/start.sh
+++ b/ui-automation/start.sh
@@ -3,7 +3,13 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-docker compose up --build -d
+if [[ "$1" == "--ci" ]]; then
+  echo "Running in CI mode"
+  docker compose up -d
+else
+  echo "Running in local mode"
+  docker compose up --build -d
+fi
 
 echo "Waiting for services to start..."
 while ! curl -s http://localhost:5050 > /dev/null || ! curl -s http://localhost:3000 > /dev/null; do


### PR DESCRIPTION
# E2E Testing Update

## Changes
- Add workflow "Run E2E Tests"
- Updated branch triggers from `ui-automation` to `main` for both push and pull request events

## Testing
The workflow will automatically run on:
- Any push to the `main` branch
- Any pull request targeting the `main` branch

## How to test locally

- Install ```act```
- Run ```act push -j run-e2e-tests```

