### PR TITLE
Fix get scaffold profile for smart contract address

### DIFF
--- a/packages/nextjs/components/ConnectedAddress.tsx
+++ b/packages/nextjs/components/ConnectedAddress.tsx
@@ -2,13 +2,17 @@
 import { useAccount } from "~~/hooks/useAccount";
 import { Address } from "./scaffold-stark";
 import { Address as AddressType } from "@starknet-react/chains";
+import { useScaffoldStarkProfile } from "~~/hooks/scaffold-stark/useScaffoldStarkProfile";
 
 export const ConnectedAddress = () => {
   const connectedAddress = useAccount();
+
+  const { data: fetchedProfile, isLoading } = useScaffoldStarkProfile(connectedAddress.address as AddressType);
+
   return (
     <div className="flex justify-center items-center space-x-2">
       <p className="my-2 font-medium text-[#00A3FF]">Connected Address:</p>
-      <Address address={connectedAddress.address as AddressType} />
+      <Address address={connectedAddress.address as AddressType} profile={fetchedProfile} isLoading={isLoading} />
     </div>
   );
 };

--- a/packages/nextjs/components/ConnectedAddress.tsx
+++ b/packages/nextjs/components/ConnectedAddress.tsx
@@ -1,18 +1,17 @@
 "use client";
 import { useAccount } from "~~/hooks/useAccount";
 import { Address } from "./scaffold-stark";
-import { Address as AddressType } from "@starknet-react/chains";
 import { useScaffoldStarkProfile } from "~~/hooks/scaffold-stark/useScaffoldStarkProfile";
 
 export const ConnectedAddress = () => {
   const connectedAddress = useAccount();
 
-  const { data: fetchedProfile, isLoading } = useScaffoldStarkProfile(connectedAddress.address as AddressType);
+  const { data: fetchedProfile, isLoading } = useScaffoldStarkProfile(connectedAddress.address);
 
   return (
     <div className="flex justify-center items-center space-x-2">
       <p className="my-2 font-medium text-[#00A3FF]">Connected Address:</p>
-      <Address address={connectedAddress.address as AddressType} profile={fetchedProfile} isLoading={isLoading} />
+      <Address address={connectedAddress.address} profile={fetchedProfile} isLoading={isLoading} />
     </div>
   );
 };

--- a/packages/nextjs/components/scaffold-stark/Address.tsx
+++ b/packages/nextjs/components/scaffold-stark/Address.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { Address as AddressType } from "@starknet-react/chains";
-import { getChecksumAddress, validateChecksumAddress } from "starknet";
+import { getChecksumAddress, StarkProfile, validateChecksumAddress } from "starknet";
 import { devnet } from "@starknet-react/chains";
 import {
   CheckCircleIcon,
@@ -22,6 +22,8 @@ type AddressProps = {
   address?: AddressType;
   disableAddressLink?: boolean;
   format?: "short" | "long";
+  profile?: StarkProfile;
+  isLoading?: boolean;
   size?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
 };
 
@@ -42,13 +44,14 @@ export const Address = ({
   address,
   disableAddressLink,
   format,
+  profile,
+  isLoading,
   size = "base",
 }: AddressProps) => {
   const [ensAvatar, setEnsAvatar] = useState<string | null>();
   const [addressCopied, setAddressCopied] = useState(false);
 
   const { targetNetwork } = useTargetNetwork();
-  const { data: fetchedProfile, isLoading } = useScaffoldStarkProfile(address);
 
   const checkSumAddress = useMemo(() => {
     if (!address) return undefined;
@@ -85,8 +88,8 @@ export const Address = ({
   useEffect(() => {
     const addressWithFallback = checkSumAddress || address || "";
 
-    if (fetchedProfile?.name) {
-      setDisplayAddress(fetchedProfile.name);
+    if (profile?.name) {
+      setDisplayAddress(profile.name);
     } else if (format === "long") {
       setDisplayAddress(addressWithFallback || "");
     } else {
@@ -94,7 +97,7 @@ export const Address = ({
         addressWithFallback.slice(0, 6) + "..." + addressWithFallback.slice(-4),
       );
     }
-  }, [fetchedProfile, checkSumAddress, address, format]);
+  }, [profile, checkSumAddress, address, format]);
 
   // Skeleton UI
   if (isLoading) {
@@ -121,9 +124,9 @@ export const Address = ({
   return (
     <div className="flex items-center">
       <div className="flex-shrink-0">
-        {getStarknetPFPIfExists(fetchedProfile?.profilePicture) ? (
+        {getStarknetPFPIfExists(profile?.profilePicture) ? (
           <NextImage
-            src={fetchedProfile?.profilePicture || ""}
+            src={profile?.profilePicture || ""}
             alt="Profile Picture"
             className="rounded-full"
             width={24}
@@ -139,12 +142,12 @@ export const Address = ({
       </div>
       {disableAddressLink ? (
         <span className={`ml-1.5 text-${size} font-normal`}>
-          {fetchedProfile?.name || displayAddress}
+          {profile?.name || displayAddress}
         </span>
       ) : targetNetwork.network === devnet.network ? (
         <span className={`ml-1.5 text-${size} font-normal`}>
           <Link href={blockExplorerAddressLink}>
-            {fetchedProfile?.name || displayAddress}
+            {profile?.name || displayAddress}
           </Link>
         </span>
       ) : (
@@ -154,7 +157,7 @@ export const Address = ({
           href={blockExplorerAddressLink}
           rel="noopener noreferrer"
         >
-          {fetchedProfile?.name || displayAddress}
+          {profile?.name || displayAddress}
         </a>
       )}
       {addressCopied ? (

--- a/packages/nextjs/components/scaffold-stark/Address.tsx
+++ b/packages/nextjs/components/scaffold-stark/Address.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { Address as AddressType } from "@starknet-react/chains";
-import { getChecksumAddress, StarkProfile, validateChecksumAddress } from "starknet";
+import { getChecksumAddress, StarkProfile } from "starknet";
 import { devnet } from "@starknet-react/chains";
 import {
   CheckCircleIcon,
@@ -13,10 +13,8 @@ import {
 import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";
 import { getBlockExplorerAddressLink } from "~~/utils/scaffold-stark";
 import { BlockieAvatar } from "~~/components/scaffold-stark/BlockieAvatar";
-import { useScaffoldStarkProfile } from "~~/hooks/scaffold-stark/useScaffoldStarkProfile";
 import { getStarknetPFPIfExists } from "~~/utils/profile";
 import { default as NextImage } from "next/image";
-import ConnectModal from "./CustomConnectButton/ConnectModal";
 
 type AddressProps = {
   address?: AddressType;

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldStarkProfile.tsx
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldStarkProfile.tsx
@@ -62,7 +62,9 @@ export const fetchProfileFromApi = async (address: string) => {
 
     // Suppress known "no data" error, log all others
     if (!error.message.includes("No data found")) {
-      console.error("Error fetching profile from API: ", error);
+      console.log("Error fetching profile from API: ", error);
+    } else {
+      console.log(`No data found for profile from API: ${address}`);
     }
 
     return {


### PR DESCRIPTION
# SS2-29

Fixes #487

## Types of change

- [x] Bug

## Comments (optional)

### Changes

- Add log info instead of log error
- Only fetch scaffold profile for connected address instead of all address thats using ```Address``` component
- Remove unused lib
