### PR TITLE
Fixed the Hook useScaffoldEventHistory shows contract not found issue

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
@@ -76,14 +76,19 @@ export const useScaffoldEventHistory = <
   }, [targetNetwork.rpcUrls.public.http]);
 
   const readEvents = async (fromBlock?: bigint) => {
+    if (!enabled) {
+      setIsLoading(false);
+      return;
+    }
+
     setIsLoading(true);
     try {
-      if (!deployedContractData) {
-        throw new Error("Contract not found");
+      if (deployedContractLoading) {
+        return;
       }
 
-      if (!enabled) {
-        throw new Error("Hook disabled");
+      if (!deployedContractData) {
+        throw new Error("Contract not found");
       }
 
       const event = (deployedContractData.abi as Abi).find(
@@ -227,7 +232,7 @@ export const useScaffoldEventHistory = <
 
   return {
     data: eventHistoryData,
-    isLoading: isLoading,
+    isLoading: isLoading || deployedContractLoading,
     error: error,
   };
 };

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
@@ -86,7 +86,7 @@ export const useScaffoldMultiWriteContract = <
       return await sendTxnWrapper(parsedCalls);
     } catch (e: any) {
       throw e;
-    } 
+    }
   };
 
   return {

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
@@ -71,7 +71,7 @@ export const useScaffoldWriteContract = <
         return await sendTxnWrapper(newCalls as any[]);
       } catch (e: any) {
         throw e;
-      } 
+      }
     },
     [
       args,


### PR DESCRIPTION
# Fixed the Hook useScaffoldEventHistory shows contract not found issue

Fixes [#218](https://github.com/Scaffold-Stark/speedrunstark/issues/218)

## Types of change

- [ ] Feature
- [X] Bug
- [ ] Enhancement

## useScaffoldEventHistory changes:
 - do not read event if not enabled
 - wait for contract to be deplpoyed, then throw error if deployedContractData not found
 - proper isLoading state
