### PR TITLE
Fixes docs URL on .env.example

### DIFF
--- a/packages/snfoundry/.env.example
+++ b/packages/snfoundry/.env.example
@@ -4,7 +4,7 @@
 # ## last staknet devnet account address
 # ACCOUNT_ADDRESS_DEVNET=0x4b3f4ba8c00a02b66142a4b1dd41a4dfab4f92650922a3280977b0f03c75ee1
 #
-# For the full deployment configuration options visit:  https://docs.scaffoldstark.com/deploying/deploy-smart-contracts
+# For the full deployment configuration options visit:  https://scaffoldstark.com/docs/deploying/deploy-smart-contracts
 
 ## Sepolia 
 # Below input your testnet private key


### PR DESCRIPTION
#  Update Docs URL in .env.example

The URL regarding deploying contracts was outdated (giving 503)

## Types of change

- [x] Bug
