### PR TITLE
Fix: Shortened Event Argument Names in useScaffoldEventHistory Hook

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldEventHistory.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldEventHistory.test.ts
@@ -22,7 +22,7 @@ vi.mock("@starknet-react/core", () => ({
 
 describe("useScaffoldEventHistory", () => {
   const mockContractName = "YourContract";
-  const mockEventName = "contracts::YourContract::YourContract::EventParser";
+  const mockEventName = "EventParser";
   const mockTargetNetwork = {
     id: "testnet",
     rpcUrls: {

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
@@ -76,24 +76,27 @@ export const useScaffoldEventHistory = <
   }, [targetNetwork.rpcUrls.public.http]);
 
   // Get back event full name
-  const matchingAbiEvents = (deployedContractData?.abi as Abi).filter(
+  const matchingAbiEvents = useMemo(() => {
+    return (deployedContractData?.abi as Abi)?.filter(
     (part) =>
       part.type === "event" &&
       part.name.split("::").slice(-1)[0] === (eventName as string),
   ) as ExtractAbiEvent<ContractAbi<TContractName>, TEventName>[];
+  }, [deployedContractData, deployedContractLoading])
+  // const matchingAbiEvents = 
 
-  if (matchingAbiEvents.length === 0) {
+  if (matchingAbiEvents?.length === 0) {
     throw new Error(`Event ${eventName as string} not found in contract ABI`);
   }
 
-  if (matchingAbiEvents.length > 1) {
+  if (matchingAbiEvents?.length > 1) {
     throw new Error(
       `Ambiguous event "${eventName as string}". ABI contains ${matchingAbiEvents.length} events with that name`,
     );
   }
 
-  const eventAbi = matchingAbiEvents[0];
-  const fullName = eventAbi.name;
+  const eventAbi = matchingAbiEvents?.[0];
+  const fullName = eventAbi?.name;
 
   const readEvents = async (fromBlock?: bigint) => {
     if (!enabled) {

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
@@ -76,18 +76,20 @@ export const useScaffoldEventHistory = <
   }, [targetNetwork.rpcUrls.public.http]);
 
   // Get back event full name
-  const matchingAbiEvents = (deployedContractData?.abi as Abi)
-    .filter(
-      (part) => part.type === "event" && 
-        part.name.split("::").slice(-1)[0] === (eventName as string)
-    ) as ExtractAbiEvent<ContractAbi<TContractName>, TEventName>[];
+  const matchingAbiEvents = (deployedContractData?.abi as Abi).filter(
+    (part) =>
+      part.type === "event" &&
+      part.name.split("::").slice(-1)[0] === (eventName as string),
+  ) as ExtractAbiEvent<ContractAbi<TContractName>, TEventName>[];
 
   if (matchingAbiEvents.length === 0) {
     throw new Error(`Event ${eventName as string} not found in contract ABI`);
   }
 
   if (matchingAbiEvents.length > 1) {
-    throw new Error(`Ambiguous event "${eventName as string}". ABI contains ${matchingAbiEvents.length} events with that name`);
+    throw new Error(
+      `Ambiguous event "${eventName as string}". ABI contains ${matchingAbiEvents.length} events with that name`,
+    );
   }
 
   const eventAbi = matchingAbiEvents[0];
@@ -112,7 +114,7 @@ export const useScaffoldEventHistory = <
       const event = (deployedContractData.abi as Abi).find(
         (part) =>
           part.type === "event" &&
-          part.name.split("::").slice(-1)[0] === eventName
+          part.name.split("::").slice(-1)[0] === eventName,
       ) as ExtractAbiEvent<ContractAbi<TContractName>, TEventName>;
 
       const blockNumber = (await publicClient.getBlockLatestAccepted())
@@ -122,9 +124,7 @@ export const useScaffoldEventHistory = <
         (fromBlock && blockNumber >= fromBlock) ||
         blockNumber >= fromBlockUpdated
       ) {
-        let keys: string[][] = [
-          [hash.getSelectorFromName(eventName)],
-        ];
+        let keys: string[][] = [[hash.getSelectorFromName(eventName)]];
         if (filters) {
           keys = keys.concat(
             composeEventFilterKeys(filters, event, deployedContractData.abi),

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
@@ -78,12 +78,12 @@ export const useScaffoldEventHistory = <
   // Get back event full name
   const matchingAbiEvents = useMemo(() => {
     return (deployedContractData?.abi as Abi)?.filter(
-    (part) =>
-      part.type === "event" &&
-      part.name.split("::").slice(-1)[0] === (eventName as string),
-  ) as ExtractAbiEvent<ContractAbi<TContractName>, TEventName>[];
-  }, [deployedContractData, deployedContractLoading])
-  // const matchingAbiEvents = 
+      (part) =>
+        part.type === "event" &&
+        part.name.split("::").slice(-1)[0] === (eventName as string),
+    ) as ExtractAbiEvent<ContractAbi<TContractName>, TEventName>[];
+  }, [deployedContractData, deployedContractLoading]);
+  // const matchingAbiEvents =
 
   if (matchingAbiEvents?.length === 0) {
     throw new Error(`Event ${eventName as string} not found in contract ABI`);

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
@@ -92,7 +92,10 @@ export const useScaffoldEventHistory = <
       }
 
       const event = (deployedContractData.abi as Abi).find(
-        (part) => part.type === "event" && part.name === eventName,
+        (part) =>
+          part.type === "event" &&
+          (part.name.split("::").slice(-1)[0] === eventName ||
+            part.name === eventName),
       ) as ExtractAbiEvent<ContractAbi<TContractName>, TEventName>;
 
       const blockNumber = (await publicClient.getBlockLatestAccepted())

--- a/packages/nextjs/utils/scaffold-stark/contract.ts
+++ b/packages/nextjs/utils/scaffold-stark/contract.ts
@@ -373,7 +373,7 @@ export type UseScaffoldEventHistoryConfig<
 > = {
   contractName: TContractName;
   eventName:
-    | IsContractDeclarationMissing<string, TEventName>
+    // | IsContractDeclarationMissing<string, TEventName>
     | BaseName<IsContractDeclarationMissing<string, TEventName>>;
   fromBlock: bigint;
   filters?: { [key: string]: any };

--- a/packages/nextjs/utils/scaffold-stark/contract.ts
+++ b/packages/nextjs/utils/scaffold-stark/contract.ts
@@ -360,6 +360,10 @@ export type EventFilters<
     }
 >;*/
 
+type BaseName<S extends string> = S extends `${infer _Prefix}::${infer Rest}`
+  ? BaseName<Rest>
+  : S;
+
 export type UseScaffoldEventHistoryConfig<
   TContractName extends ContractName,
   TEventName extends ExtractAbiEventNames<ContractAbi<TContractName>>,
@@ -368,7 +372,9 @@ export type UseScaffoldEventHistoryConfig<
   TReceiptData extends boolean = false,
 > = {
   contractName: TContractName;
-  eventName: IsContractDeclarationMissing<string, TEventName>;
+  eventName:
+    | IsContractDeclarationMissing<string, TEventName>
+    | BaseName<IsContractDeclarationMissing<string, TEventName>>;
   fromBlock: bigint;
   filters?: { [key: string]: any };
   blockData?: TBlockData;

--- a/packages/nextjs/utils/scaffold-stark/contract.ts
+++ b/packages/nextjs/utils/scaffold-stark/contract.ts
@@ -372,9 +372,8 @@ export type UseScaffoldEventHistoryConfig<
   TReceiptData extends boolean = false,
 > = {
   contractName: TContractName;
-  eventName:
-    // | IsContractDeclarationMissing<string, TEventName>
-    | BaseName<IsContractDeclarationMissing<string, TEventName>>;
+  eventName: // | IsContractDeclarationMissing<string, TEventName>
+  BaseName<IsContractDeclarationMissing<string, TEventName>>;
   fromBlock: bigint;
   filters?: { [key: string]: any };
   blockData?: TBlockData;


### PR DESCRIPTION
# SS2: Shorten Event Argument Names for useScaffoldEventHistory

Fixes #543 

## Types of change

- [ ] Feature
- [ ] Bug
- [x] Enhancement

## Comments 

I constructed a new type to interact with another type, and extract the base name of the argument type it is given, so that 'Transfer' can be extracted from the long event name for instance, and the auto-complete still recognizes it. I changed this type in the UseScaffoldEventHistoryConfig (more like added, with an or separator so that both methods can be used). Then in the readEvents function, I made sure to check either the basename or the full name of the events for matching with the eventName argument.

Details in code, it was a very small change
