### PR TITLE
fix: error when navigating to Debug Contracts (Challenge 1 & 2) 

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
@@ -17,6 +17,7 @@ import { AbiFunction } from "~~/utils/scaffold-stark/contract";
 import { BlockNumber } from "starknet";
 import { useContract, useReadContract } from "@starknet-react/core";
 import { ContractInput } from "./ContractInput";
+import { isValidContractArgs } from "~~/utils/scaffold-stark/common";
 
 type ReadOnlyFunctionFormProps = {
   contractAddress: Address;
@@ -30,7 +31,7 @@ export const ReadOnlyFunctionForm = ({
   abi,
 }: ReadOnlyFunctionFormProps) => {
   const [form, setForm] = useState<Record<string, any>>(() =>
-    getInitialFormState(abiFunction),
+    getInitialFormState(abiFunction)
   );
   const [inputValue, setInputValue] = useState<any | undefined>(undefined);
   const [formErrorMessage, setFormErrorMessage] =
@@ -42,11 +43,16 @@ export const ReadOnlyFunctionForm = ({
     address: contractAddress,
   });
 
+  const inputIsValidArray = isValidContractArgs(
+    inputValue,
+    abiFunction.inputs.length
+  );
+
   const { isFetching, data, refetch, error } = useReadContract({
     address: contractAddress,
     functionName: abiFunction.name,
     abi: [...abi],
-    args: inputValue || [],
+    args: inputIsValidArray ? inputValue : undefined,
     enabled: !!inputValue && !!contractInstance,
     blockIdentifier: "pending" as BlockNumber,
   });
@@ -76,10 +82,25 @@ export const ReadOnlyFunctionForm = ({
 
   const handleRead = () => {
     const newInputValue = getArgsAsStringInputFromForm(form);
+    const expectedArgCount = abiFunction.inputs.length;
+
+    const isValidInput = isValidContractArgs(newInputValue, expectedArgCount);
+
+    if (!isValidInput) {
+      /**
+       * Todo: add extra logging in future release.
+       */
+      console.warn(
+        `Read blocked: Expected ${expectedArgCount} args, got ${newInputValue.length}`
+      );
+      return;
+    }
+
     if (JSON.stringify(form) !== JSON.stringify(lastForm.current)) {
       setInputValue(newInputValue);
       lastForm.current = form;
     }
+
     refetch();
   };
 

--- a/packages/nextjs/utils/scaffold-stark/common.ts
+++ b/packages/nextjs/utils/scaffold-stark/common.ts
@@ -26,3 +26,14 @@ export function isJsonString(str: string) {
     return false;
   }
 }
+
+export function isValidContractArgs(
+  args: unknown,
+  expectedLength: number
+): boolean {
+  return (
+    Array.isArray(args) &&
+    args.length === expectedLength &&
+    args.every((arg) => arg !== undefined && arg !== null && arg !== "")
+  );
+}


### PR DESCRIPTION
Fixes [error when navigating to Debug Contracts (Challenge 1 & 2) ](https://github.com/Scaffold-Stark/speedrunstark/issues/249)

- Fixed `useReadContract` hook so it's only triggered when valid parameters are passed.
- Added a utility (`isValidContractArgs`) to validate contract read arguments before triggering the hook.

## Type of Change

- [ ] Feature  
- [x] Bug Fix  
- [ ] Enhancement  

## Additional Notes

The issue occurred because `useReadContract` was being called with empty or invalid argument arrays, which caused the underlying contract ABI validation to throw:  
`Invalid number of arguments, expected N arguments, but got 0`.

This is now prevented by validating the input array length and content before passing it to the hook.