### PR TITLE
fix: error when navigating to Debug Contracts (Challenge 1 & 2) 

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
@@ -31,7 +31,7 @@ export const ReadOnlyFunctionForm = ({
   abi,
 }: ReadOnlyFunctionFormProps) => {
   const [form, setForm] = useState<Record<string, any>>(() =>
-    getInitialFormState(abiFunction)
+    getInitialFormState(abiFunction),
   );
   const [inputValue, setInputValue] = useState<any | undefined>(undefined);
   const [formErrorMessage, setFormErrorMessage] =
@@ -45,7 +45,7 @@ export const ReadOnlyFunctionForm = ({
 
   const inputIsValidArray = isValidContractArgs(
     inputValue,
-    abiFunction.inputs.length
+    abiFunction.inputs.length,
   );
 
   const { isFetching, data, refetch, error } = useReadContract({
@@ -91,7 +91,7 @@ export const ReadOnlyFunctionForm = ({
        * Todo: add extra logging in future release.
        */
       console.warn(
-        `Read blocked: Expected ${expectedArgCount} args, got ${newInputValue.length}`
+        `Read blocked: Expected ${expectedArgCount} args, got ${newInputValue.length}`,
       );
       return;
     }

--- a/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ReadOnlyFunctionForm.tsx
@@ -17,6 +17,7 @@ import { AbiFunction } from "~~/utils/scaffold-stark/contract";
 import { BlockNumber } from "starknet";
 import { useContract, useReadContract } from "@starknet-react/core";
 import { ContractInput } from "./ContractInput";
+import { isValidContractArgs } from "~~/utils/scaffold-stark/common";
 
 type ReadOnlyFunctionFormProps = {
   contractAddress: Address;
@@ -30,7 +31,7 @@ export const ReadOnlyFunctionForm = ({
   abi,
 }: ReadOnlyFunctionFormProps) => {
   const [form, setForm] = useState<Record<string, any>>(() =>
-    getInitialFormState(abiFunction),
+    getInitialFormState(abiFunction)
   );
   const [inputValue, setInputValue] = useState<any | undefined>(undefined);
   const [formErrorMessage, setFormErrorMessage] =
@@ -42,11 +43,16 @@ export const ReadOnlyFunctionForm = ({
     address: contractAddress,
   });
 
+  const inputIsValidArray = isValidContractArgs(
+    inputValue,
+    abiFunction.inputs.length
+  );
+
   const { isFetching, data, refetch, error } = useReadContract({
     address: contractAddress,
     functionName: abiFunction.name,
     abi: [...abi],
-    args: inputValue || [],
+    args: inputIsValidArray ? inputValue : undefined,
     enabled: !!inputValue && !!contractInstance,
     blockIdentifier: "pending" as BlockNumber,
   });
@@ -76,10 +82,25 @@ export const ReadOnlyFunctionForm = ({
 
   const handleRead = () => {
     const newInputValue = getArgsAsStringInputFromForm(form);
+    const expectedArgCount = abiFunction.inputs.length;
+
+    const isValidInput = isValidContractArgs(newInputValue, expectedArgCount);
+
+    if (!isValidInput) {
+      /**
+       * Todo: add extra logging in future release.
+       */
+      console.warn(
+        `Read blocked: Expected ${expectedArgCount} args, got ${newInputValue.length}`
+      );
+      return;
+    }
+
     if (JSON.stringify(form) !== JSON.stringify(lastForm.current)) {
       setInputValue(newInputValue);
       lastForm.current = form;
     }
+
     refetch();
   };
 

--- a/packages/nextjs/utils/scaffold-stark/__test__/common.test.ts
+++ b/packages/nextjs/utils/scaffold-stark/__test__/common.test.ts
@@ -23,7 +23,7 @@ describe("Common Utility Functions", () => {
   describe("isAddress", () => {
     it("should return true for valid Ethereum addresses", () => {
       expect(isAddress("0x1234567890abcdef1234567890abcdef12345678")).toBe(
-        true
+        true,
       );
     });
 
@@ -31,7 +31,7 @@ describe("Common Utility Functions", () => {
       expect(isAddress("invalid_address")).toBe(false);
       expect(isAddress("0x123")).toBe(false);
       expect(isAddress("0x1234567890abcdef1234567890abcdef123456789")).toBe(
-        false
+        false,
       );
     });
   });

--- a/packages/nextjs/utils/scaffold-stark/__test__/common.test.ts
+++ b/packages/nextjs/utils/scaffold-stark/__test__/common.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { replacer, isAddress, feltToHex, isJsonString } from "../common";
+import {
+  replacer,
+  isAddress,
+  feltToHex,
+  isJsonString,
+  isValidContractArgs,
+} from "../common";
 
 describe("Common Utility Functions", () => {
   describe("replacer", () => {
@@ -17,7 +23,7 @@ describe("Common Utility Functions", () => {
   describe("isAddress", () => {
     it("should return true for valid Ethereum addresses", () => {
       expect(isAddress("0x1234567890abcdef1234567890abcdef12345678")).toBe(
-        true,
+        true
       );
     });
 
@@ -25,7 +31,7 @@ describe("Common Utility Functions", () => {
       expect(isAddress("invalid_address")).toBe(false);
       expect(isAddress("0x123")).toBe(false);
       expect(isAddress("0x1234567890abcdef1234567890abcdef123456789")).toBe(
-        false,
+        false
       );
     });
   });
@@ -46,6 +52,27 @@ describe("Common Utility Functions", () => {
     it("should return false for invalid JSON strings", () => {
       expect(isJsonString("{key: value}")).toBe(false);
       expect(isJsonString("invalid_json")).toBe(false);
+    });
+  });
+  describe("isValidContractArgs", () => {
+    it("should return true for valid arguments with correct length", () => {
+      expect(isValidContractArgs([1, "test", true], 3)).toBe(true);
+    });
+
+    it("should return false if not an array", () => {
+      expect(isValidContractArgs("not-an-array", 3)).toBe(false);
+      expect(isValidContractArgs(null, 3)).toBe(false);
+    });
+
+    it("should return false if length does not match", () => {
+      expect(isValidContractArgs([1, 2], 3)).toBe(false);
+      expect(isValidContractArgs([1, 2, 3, 4], 3)).toBe(false);
+    });
+
+    it("should return false if any element is undefined, null, or empty string", () => {
+      expect(isValidContractArgs([1, undefined, 3], 3)).toBe(false);
+      expect(isValidContractArgs([1, null, 3], 3)).toBe(false);
+      expect(isValidContractArgs([1, "", 3], 3)).toBe(false);
     });
   });
 });

--- a/packages/nextjs/utils/scaffold-stark/common.ts
+++ b/packages/nextjs/utils/scaffold-stark/common.ts
@@ -26,3 +26,14 @@ export function isJsonString(str: string) {
     return false;
   }
 }
+
+export function isValidContractArgs(
+  args: unknown,
+  expectedLength: number
+): boolean {
+  return (
+    Array.isArray(args) &&
+    args.length === expectedLength &&
+    args.every((arg) => arg !== undefined && arg !== null && arg !== "")
+  );
+}

--- a/packages/nextjs/utils/scaffold-stark/common.ts
+++ b/packages/nextjs/utils/scaffold-stark/common.ts
@@ -29,7 +29,7 @@ export function isJsonString(str: string) {
 
 export function isValidContractArgs(
   args: unknown,
-  expectedLength: number
+  expectedLength: number,
 ): boolean {
   return (
     Array.isArray(args) &&


### PR DESCRIPTION
Fixes [error when navigating to Debug Contracts (Challenge 1 & 2) ](https://github.com/Scaffold-Stark/speedrunstark/issues/249)

- Fixed `useReadContract` hook so it's only triggered when valid parameters are passed.
- Added a utility (`isValidContractArgs`) to validate contract read arguments before triggering the hook.

## Type of Change

- [ ] Feature  
- [x] Bug Fix  
- [ ] Enhancement  

## Additional Notes

The issue occurred because `useReadContract` was being called with empty or invalid argument arrays, which caused the underlying contract ABI validation to throw:  
`Invalid number of arguments, expected N arguments, but got 0`.

This is now prevented by validating the input array length and content before passing it to the hook.