### PR TITLE
Feat: Compress other wallets into a modal on DEVNET

### DIFF
--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
@@ -7,6 +7,7 @@ import { useTheme } from "next-themes";
 import { BlockieAvatar } from "../BlockieAvatar";
 import GenericModal from "./GenericModal";
 import { LAST_CONNECTED_TIME_LOCALSTORAGE_KEY } from "~~/utils/Constants";
+import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";
 
 const loader = ({ src }: { src: string }) => src;
 
@@ -28,6 +29,23 @@ const ConnectModal = () => {
     "wasDisconnectedManually",
     false,
   );
+  const { targetNetwork } = useTargetNetwork();
+  const [showOtherOptions, setShowOtherOptions] = useState(false);
+
+  // Identify devnet by network name
+  const isDevnet = targetNetwork.network === "devnet";
+
+  // Split connectors into main and other options for devnet
+  let mainConnectors = connectors;
+  let otherConnectors: typeof connectors = [];
+  if (isDevnet) {
+    mainConnectors = connectors.filter(
+      (c) => c.id === "burner-wallet"
+    );
+    otherConnectors = connectors.filter(
+      (c) => c.id !== "burner-wallet"
+    );
+  }
 
   const handleCloseModal = () => {
     if (modalRef.current) modalRef.current.checked = false;
@@ -81,10 +99,17 @@ const ConnectModal = () => {
         <>
           <div className="flex items-center justify-between">
             <h3 className="text-xl font-bold">
-              {isBurnerWallet ? "Choose account" : "Connect a Wallet"}
+              {isBurnerWallet
+                ? "Choose account"
+                : showOtherOptions
+                  ? "Other Wallet Options"
+                  : "Connect a Wallet"}
             </h3>
             <label
-              onClick={() => setIsBurnerWallet(false)}
+              onClick={() => {
+                setIsBurnerWallet(false);
+                setShowOtherOptions(false);
+              }}
               htmlFor="connect-modal"
               className="btn btn-ghost btn-sm btn-circle cursor-pointer"
             >
@@ -94,14 +119,43 @@ const ConnectModal = () => {
           <div className="flex flex-col flex-1 lg:grid">
             <div className="flex flex-col gap-4 w-full px-8 py-10">
               {!isBurnerWallet ? (
-                connectors.map((connector, index) => (
-                  <Wallet
-                    key={connector.id || index}
-                    connector={connector}
-                    loader={loader}
-                    handleConnectWallet={handleConnectWallet}
-                  />
-                ))
+                !showOtherOptions ? (
+                  <>
+                    {mainConnectors.map((connector, index) => (
+                      <Wallet
+                        key={connector.id || index}
+                        connector={connector}
+                        loader={loader}
+                        handleConnectWallet={handleConnectWallet}
+                      />
+                    ))}
+                    {isDevnet && otherConnectors.length > 0 && (
+                      <button
+                        className="btn btn-outline mt-4"
+                        onClick={() => setShowOtherOptions(true)}
+                      >
+                        Other Options
+                      </button>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    {otherConnectors.map((connector, index) => (
+                      <Wallet
+                        key={connector.id || index}
+                        connector={connector}
+                        loader={loader}
+                        handleConnectWallet={handleConnectWallet}
+                      />
+                    ))}
+                    <button
+                      className="btn  mt-4"
+                      onClick={() => setShowOtherOptions(false)}
+                    >
+                      Back
+                    </button>
+                  </>
+                )
               ) : (
                 <div className="flex flex-col pb-[20px] justify-end gap-3">
                   <div className="h-[300px] overflow-y-auto flex w-full flex-col gap-2">


### PR DESCRIPTION
# In DEVNET only: Hide Argent, Braavos, and other 3rd-party wallet buttons from the main wallet connect modal.


- Fixes: #572 

## Types of change

- [x] Feature
- [ ] Bug
- [ ] Enhancement

## Summary of Steps
1. Detect if the app is running on DEVNET.
2. In the wallet connect modal,
     - If on DEVNET, show only default wallet(s) + “Other Options” button.
     - On “Other Options” click, show a modal with Argent, Braavos, etc.
3. If not on DEVNET, show all wallets as usual.
