### PR TITLE
chore: make vitest pass with no tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
         working-directory: ./packages/nextjs
 
       - name: Run Next.js tests
-        run: yarn test run
+        run: yarn test
         working-directory: ./packages/nextjs
 
       - name: Build Next.js project

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "postinstall": "shx cp -n .env.example .env",
-    "test": "vitest",
+    "test": "vitest run --passWithNoTests",
     "coverage": "vitest run --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
# Make vitest pass with no tests

To prevent CI errors in Forks (in particular speedrun repositories), we designate `vitest` to pass if there are no test suites defined

## Types of change

- [ ] Feature
- [ ] Bug
- [X] Enhancement

## Comments (optional)
