### PR TITLE
feat: add multicall contract & hook

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiReadContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiReadContract.ts
@@ -1,0 +1,117 @@
+import {
+  ContractAbi,
+  ContractName,
+  contracts,
+  ExtractAbiFunctionNamesScaffold,
+  UseScaffoldReadConfig,
+  Contract,
+} from "~~/utils/scaffold-stark/contract";
+import { Abi, UseReadContractProps } from "@starknet-react/core";
+import { hash, CallData } from "starknet";
+import { useTargetNetwork } from "./useTargetNetwork";
+import { useMemo } from "react";
+import { useScaffoldReadContract } from "./useScaffoldReadContract";
+
+type ScaffoldReadCall<
+  TAbi extends Abi,
+  TContractName extends ContractName,
+  TFunctionName extends ExtractAbiFunctionNamesScaffold<
+    ContractAbi<TContractName>,
+    "view"
+  >,
+> = Pick<
+  UseScaffoldReadConfig<TAbi, TContractName, TFunctionName>,
+  "functionName" | "contractName" | "args"
+>;
+
+type UseScaffoldMultiReadConfig = Omit<
+  UseReadContractProps<Abi, "view">,
+  "address" | "abi" | "functionName" | "args" | "chainId"
+>;
+
+type UseScaffoldMultiReadProps<
+  TAbi extends Abi,
+  TContractName extends ContractName,
+  TFunctionName extends ExtractAbiFunctionNamesScaffold<
+    ContractAbi<TContractName>,
+    "view"
+  >,
+> = UseScaffoldMultiReadConfig & {
+  calls: Array<ScaffoldReadCall<TAbi, TContractName, TFunctionName>>;
+};
+
+export const useScaffoldMultiReadContract = <
+  TAbi extends Abi,
+  TContractName extends ContractName,
+  TFunctionName extends ExtractAbiFunctionNamesScaffold<
+    ContractAbi<TContractName>,
+    "view"
+  >,
+>({
+  calls,
+  ...restConfig
+}: UseScaffoldMultiReadProps<TAbi, TContractName, TFunctionName>) => {
+  const { targetNetwork } = useTargetNetwork();
+
+  const { addresses, fnSelectors, rawArgs, callDataHelpers } = useMemo(() => {
+    const parsedCalls = (calls ?? []).map((call) => {
+      const { functionName, contractName, args } = call;
+
+      // TODO: handle error if contract is not found
+      const contract = contracts?.[targetNetwork.network]?.[
+        contractName as ContractName
+      ] as Contract<TContractName>;
+      const { abi, address } = contract;
+
+      const callDataHelper = new CallData(abi);
+      const rawArg = args ? callDataHelper.compile(functionName, args) : [];
+      const fnSelector = hash.getSelectorFromName(functionName);
+
+      return {
+        address,
+        callDataHelper,
+        fnSelector,
+        rawArg,
+      };
+    });
+
+    const addresses = parsedCalls.map((call) => call.address);
+    const fnSelectors = parsedCalls.map((call) => call.fnSelector);
+    const rawArgs = parsedCalls.map((call) => call.rawArg);
+    const callDataHelpers = parsedCalls.map((call) => call.callDataHelper);
+
+    return {
+      addresses,
+      fnSelectors,
+      rawArgs,
+      callDataHelpers,
+    };
+  }, [calls, targetNetwork]);
+
+  const useReadContractResult = useScaffoldReadContract({
+    ...restConfig,
+    contractName: "Multicall",
+    functionName: "call_contracts",
+    args: [addresses, fnSelectors, rawArgs],
+  });
+
+  const parsedData = useMemo(() => {
+    // TODO: find the way to remove as bigint[][]
+    const typedData = useReadContractResult.data as bigint[][] | undefined;
+
+    if (!typedData) return typedData;
+
+    return typedData.map((raw, index) => {
+      const { functionName, contractName } = calls[index];
+      const callDataHelper = callDataHelpers[index];
+      const parsedData = callDataHelper.parse(
+        functionName,
+        raw.map((b) => b.toString()),
+      );
+
+      return parsedData;
+    });
+  }, [useReadContractResult.data]);
+
+  return { ...useReadContractResult, parsedData: parsedData };
+};

--- a/packages/snfoundry/contracts/src/Multicall.cairo
+++ b/packages/snfoundry/contracts/src/Multicall.cairo
@@ -1,0 +1,45 @@
+use starknet::ContractAddress;
+#[starknet::interface]
+pub trait IMulticall<T> {
+    fn call_contracts(
+        self: @T,
+        contracts: Span<ContractAddress>,
+        entry_point_selectors: Span<felt252>,
+        calldata: Span<Span<felt252>>,
+    ) -> Array<Span<felt252>>;
+}
+
+#[starknet::contract]
+pub mod Multicall {
+    use core::array::ArrayTrait;
+    use starknet::ContractAddress;
+    use starknet::syscalls::call_contract_syscall;
+    use super::IMulticall;
+
+    #[storage]
+    struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState) {}
+
+
+    #[abi(embed_v0)]
+    impl MulticallImpl of IMulticall<ContractState> {
+        fn call_contracts(
+            self: @ContractState,
+            contracts: Span<ContractAddress>,
+            entry_point_selectors: Span<felt252>,
+            calldata: Span<Span<felt252>>,
+        ) -> Array<Span<felt252>> {
+            let mut results: Array<Span<felt252>> = ArrayTrait::new();
+            for i in 0..contracts.len() {
+                let contract = *contracts[i];
+                let entry_point_selector = *entry_point_selectors[i];
+                let calldata = *calldata[i];
+                let result = call_contract_syscall(contract, entry_point_selector, calldata);
+                results.append(result.unwrap());
+            }
+            results
+        }
+    }
+}

--- a/packages/snfoundry/contracts/src/lib.cairo
+++ b/packages/snfoundry/contracts/src/lib.cairo
@@ -1,2 +1,2 @@
+pub mod Multicall;
 pub mod YourContract;
-

--- a/packages/snfoundry/scripts-ts/deploy.ts
+++ b/packages/snfoundry/scripts-ts/deploy.ts
@@ -50,6 +50,10 @@ const deployScript = async (): Promise<void> => {
       owner: deployer.address,
     },
   });
+  await deployContract({
+    contract: "Multicall",
+    contractName: "Multicall",
+  });
 };
 
 const main = async (): Promise<void> => {


### PR DESCRIPTION
# Implement useScaffoldMultiReadContract hook

Fixes #575 

## Types of change

- [X] Feature
- [ ] Bug
- [ ] Enhancement

## Comments (optional)
- There’s no official Multicall contract interface on Starknet, so I used the one that’s recommended
- The return data type still needs improvement
- I tried reusing useReadContract => error handling for parsing progress is not included