### PR TITLE
chore(deps): Update Starknet Foundry to 0.46.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 scarb 2.11.4
-starknet-foundry 0.45.0
+starknet-foundry 0.46.0
 starknet-devnet 0.4.3

--- a/README.md
+++ b/README.md
@@ -162,31 +162,6 @@ Now you are ready!!!
 - Cairo - v2.11.4
 - Rpc - v0.8.0
 
-## Dependency Resolution
-
-If you encounter dependency version conflicts when running `scarb build`, this is typically due to incompatible version requirements between packages. Common issues include:
-
-### OpenZeppelin Testing Compatibility
-
-The project uses `openzeppelin_testing = "4.3.0"` which is compatible with `snforge_std = "0.46.0"`. If you see errors about version conflicts between these packages:
-
-1. **Check your Scarb.toml**: Ensure you're using compatible versions:
-   ```toml
-   [dev-dependencies]
-   openzeppelin_testing = "4.3.0"
-   snforge_std = "0.46.0"
-   ```
-
-2. **Update dependencies**: If using older versions, update to the compatible versions listed above.
-
-3. **Clear cache**: Sometimes clearing the Scarb cache helps:
-   ```bash
-   scarb clean
-   scarb build
-   ```
-
-For more detailed troubleshooting, refer to the [Scarb documentation](https://docs.swmansion.com/scarb/docs.html).
-
 ## Quickstart 1: Deploying a Smart Contract to Starknet-Devnet
 
 To get started with Scaffold-Stark, follow the steps below:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Now you have a new project with the basic structure.
 #### 1.3 Troubleshooting
 
 - If you run into version errors after using `starkup` or `asdf`, you can try to install the dependencies manually. Check the details below.
+- If you encounter dependency version conflicts during `scarb build`, see the [Dependency Resolution](#dependency-resolution) section below.
 
 <details>
 
@@ -94,19 +95,19 @@ Otherwise, you can install Scarb `2.11.4` following the [instructions](https://d
 
 #### Starknet Foundry version
 
-To ensure the proper functioning of the tests on scaffold-stark, your `Starknet Foundry` version must be `0.45.0`. To accomplish this, first check your `Starknet Foundry` version:
+To ensure the proper functioning of the tests on scaffold-stark, your `Starknet Foundry` version must be `0.46.0`. To accomplish this, first check your `Starknet Foundry` version:
 
 ```sh
 snforge --version
 ```
 
-If your `Starknet Foundry` version is not `0.45.0`, you need to install it. If you already have installed `Starknet Foundry` via `starkup`, you can setup this specific version with the following command:
+If your `Starknet Foundry` version is not `0.46.0`, you need to install it. If you already have installed `Starknet Foundry` via `starkup`, you can setup this specific version with the following command:
 
 ```sh
-asdf install starknet-foundry 0.45.0 && asdf set starknet-foundry 0.45.0
+asdf install starknet-foundry 0.46.0 && asdf set starknet-foundry 0.46.0
 ```
 
-Otherwise, you can install Starknet Foundry `0.45.0` following the [instructions](https://foundry-rs.github.io/starknet-foundry/getting-started/installation.html#installation-via-asdf).
+Otherwise, you can install Starknet Foundry `0.46.0` following the [instructions](https://foundry-rs.github.io/starknet-foundry/getting-started/installation.html#installation-via-asdf).
 
 #### Starknet-devnet version
 
@@ -157,9 +158,34 @@ Now you are ready!!!
 
 - Starknet-devnet - 0.4.3
 - Scarb - v2.11.4
-- Snforge - v0.45.0
+- Snforge - v0.46.0
 - Cairo - v2.11.4
 - Rpc - v0.8.0
+
+## Dependency Resolution
+
+If you encounter dependency version conflicts when running `scarb build`, this is typically due to incompatible version requirements between packages. Common issues include:
+
+### OpenZeppelin Testing Compatibility
+
+The project uses `openzeppelin_testing = "4.3.0"` which is compatible with `snforge_std = "0.46.0"`. If you see errors about version conflicts between these packages:
+
+1. **Check your Scarb.toml**: Ensure you're using compatible versions:
+   ```toml
+   [dev-dependencies]
+   openzeppelin_testing = "4.3.0"
+   snforge_std = "0.46.0"
+   ```
+
+2. **Update dependencies**: If using older versions, update to the compatible versions listed above.
+
+3. **Clear cache**: Sometimes clearing the Scarb cache helps:
+   ```bash
+   scarb clean
+   scarb build
+   ```
+
+For more detailed troubleshooting, refer to the [Scarb documentation](https://docs.swmansion.com/scarb/docs.html).
 
 ## Quickstart 1: Deploying a Smart Contract to Starknet-Devnet
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ss-2",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "author": "Q3 Labs",
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ss-2",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "author": "Q3 Labs",
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ss-2",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "author": "Q3 Labs",
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ss-2",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "author": "Q3 Labs",
   "license": "MIT",
   "private": true,

--- a/packages/snfoundry/contracts/Scarb.lock
+++ b/packages/snfoundry/contracts/Scarb.lock
@@ -39,9 +39,9 @@ checksum = "sha256:87773ed6cd2318f169283ecbbb161890d1996260a80302d81ec45b70ee5e5
 
 [[package]]
 name = "openzeppelin_testing"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:c7a722ea85150147a7daeface39b9328d7d73ba1e73c065c5c7d92e845a240cc"
+checksum = "sha256:0cbdd8531a4bf7474a06492a671ed09f3b555e90e4a65180db341fcb43e2bcc1"
 dependencies = [
  "snforge_std",
 ]
@@ -66,15 +66,15 @@ checksum = "sha256:bf799c794139837f397975ffdf6a7ed5032d198bbf70e87a8f44f144a9dfc
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:568482e8c40e7018d9ea729d6df3d5ec22b665cfff1e89181d8ad31bacca11cc"
+checksum = "sha256:6ffa10fe0ff525678138afd584fc2012e7b248f9c8e7b44aeae033cef3ee7826"
 
 [[package]]
 name = "snforge_std"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:c08b359c266e45c4e71b71baa3c4af8dae7fc5416fc8168f0983e5c9a2ac0abe"
+checksum = "sha256:a4d4b4d3e8506a3907d1eabacb058c390aa13a70132f475cba5e3dcd7a60d0bb"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/packages/snfoundry/contracts/Scarb.toml
+++ b/packages/snfoundry/contracts/Scarb.toml
@@ -12,8 +12,8 @@ openzeppelin_token = "2.0.0"
 
 [dev-dependencies]
 openzeppelin_utils = "2.0.0"
-openzeppelin_testing = "4.2.0"
-snforge_std = "0.45.0"
+openzeppelin_testing = "4.3.0"
+snforge_std = "0.46.0"
 
 [[target.starknet-contract]]
 casm = true # taggle this to `false` to speed up compilation/script tests


### PR DESCRIPTION
# Update Starknet Foundry to 0.46.0

- Fixed dependency conflict: Updated `openzeppelin_testing` from `4.2.0` to `4.3.0` in `Scarb.toml`
- Updated compatible versions: Changed Snforge version from `v0.45.0` to `v0.46.0` in `README`
- Updated Starknet Foundry installation instructions: Changed all references from `0.45.0` to `0.46.0`
- Verified build success: Confirmed that scarb build now works without version conflicts
- Updated documentation consistency: All version references now align with current project requirements

Fixes #606 

Related PR [#61 Scaffold site](https://github.com/Scaffold-Stark/scaffoldstark-site/pull/61)

## Types of change

- [ ] Feature
- [ ] Bug
- [x] Enhancement

## Comments (optional)
