### PR TITLE
build: install scarb and starknet foundry to before deploying spolia demo contracts

### DIFF
--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -19,6 +19,17 @@ jobs:
           token: ${{ secrets.ORG_GITHUB_TOKEN }}
           path: source_repo
 
+      - name: Install scarb
+        uses: software-mansion/setup-scarb@v1
+        with:
+          tool-versions: ./.tool-versions
+          scarb-lock: ./packages/snfoundry/contracts/Scarb.lock
+
+      - name: Install snfoundryup
+        uses: foundry-rs/setup-snfoundry@v3
+        with:
+          tool-versions: ./.tool-versions
+
       - name: Modify scaffoldConfig in Source Repository
         run: |
           cd source_repo


### PR DESCRIPTION
This PR attempts to fix `YourContract` not showing on demo application, the CI on main failed to deploy due to absence of scarb. 