### PR TITLE
build: ci for checking deploy scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - "packages/nextjs/**"
       - "packages/snfoundry/contracts/**"
+      - "packages/snfoundry/scripts-ts/**"
+      - "packages/snfoundry/scripts-cairo/**"
 
 jobs:
   ci:


### PR DESCRIPTION
Currently the PR Verifier checks do not reach the scripts on the `snfoundry` directory, This PR adds those directory to the scope