### PR TITLE
fix: watch true on use transaction receipt

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-stark/useTransactor.tsx
@@ -78,6 +78,8 @@ export const useTransactor = (
   );
   const transactionReceiptInstance = useTransactionReceipt({
     hash: transactionHash,
+    enabled: !!transactionHash,
+    watch: true,
   });
   const { data: txResult, status: txStatus } = transactionReceiptInstance;
 


### PR DESCRIPTION
Fixes intermittent error of `useTransactor` not picking up successful transactions in sepolia

Before - Inconsistent time and hints of hook not picking up transaction, the three transactions are similar

<img width="359" height="91" alt="image" src="https://github.com/user-attachments/assets/1cc8a668-148d-4acb-9567-9ba4190495df" />


After - Consistent transaction times for similar transactions

<img width="338" height="95" alt="image" src="https://github.com/user-attachments/assets/24a82c79-c44e-4ccf-96b2-0b09f1cf0ac3" />

