### PR TITLE
ci: fix speedrun sync to clean up stale files

### DIFF
--- a/.github/sync-speedrun-filter-rules
+++ b/.github/sync-speedrun-filter-rules
@@ -1,0 +1,84 @@
+# Rsync filter rules for scaffold-stark-2 → speedrunstark sync
+# P = Protect (never delete from speedrunstark)
+# - = Exclude (never copy from scaffold-stark-2)
+#
+# When adding new speedrun-specific files, add a P rule here.
+# When adding new scaffold-stark-2 files that shouldn't sync, add a - rule.
+
+# === PROTECT speedrun-specific files (prevent --delete from removing them) ===
+
+# Merge strategy configs
+P .gitattributes
+P packages/nextjs/.gitattributes
+P packages/snfoundry/.gitattributes
+
+# Speedrun UI components and branding
+P packages/nextjs/components/Button/
+P packages/nextjs/components/Button/**
+P packages/nextjs/components/ButtonStyle/
+P packages/nextjs/components/ButtonStyle/**
+P packages/nextjs/components/HeaderLogo.tsx
+P packages/nextjs/components/icons/
+P packages/nextjs/components/icons/**
+
+# Speedrun fonts and assets
+P packages/nextjs/font/
+P packages/nextjs/font/**
+P packages/nextjs/public/icon-starknet.svg
+P packages/nextjs/public/logo-header.svg
+P packages/nextjs/public/speedrunStarknet.svg
+P packages/nextjs/public/starkcompass-icon.svg
+P packages/nextjs/public/Starknet-icon.svg
+P packages/nextjs/public/starknet.svg
+
+# Speedrun-specific contract files
+P packages/snfoundry/contracts/tests/TestContract.cairo
+P packages/snfoundry/scripts-ts/helpers/fees.ts
+
+# Speedrun workflows
+P .github/workflows/sync_other_challenges.yaml
+
+# Editor and dev tool configs
+P .vscode/
+P .vscode/**
+P .claude/
+P .claude/**
+
+# Speedrun project files
+P global_rules.md
+P submissions.md
+
+# === EXCLUDE from sync (never copy these from scaffold-stark-2) ===
+
+# Git directory
+- .git/
+- .git/**
+
+# Test files
+- __test__/
+- __test__/**
+- __tests__/
+- __tests__/**
+
+# Debug assets
+- packages/nextjs/public/debug-image.png
+- packages/nextjs/public/rpc-version.png
+
+# Challenge-specific files (each challenge has its own)
+- packages/snfoundry/contracts/src/your_contract.cairo
+
+# Environment files (speedrunstark has its own credentials)
+- packages/snfoundry/.env
+- packages/nextjs/.env
+
+# Deployment files (speedrunstark has its own deployments)
+- packages/snfoundry/deployments/
+
+# Docs that are rewritten for speedrunstark
+- CHANGELOG*
+- CONTRIBUTING*
+- README.md
+
+# Husky hooks (not used in speedrunstark)
+- .husky/_/
+- .husky/_/**

--- a/.github/sync-speedrun-filter-rules
+++ b/.github/sync-speedrun-filter-rules
@@ -1,0 +1,83 @@
+# Rsync filter rules for scaffold-stark-2 → speedrunstark sync
+# P = Protect (never delete from speedrunstark)
+# - = Exclude (never copy from scaffold-stark-2)
+#
+# When adding new speedrun-specific files, add a P rule here.
+# When adding new scaffold-stark-2 files that shouldn't sync, add a - rule.
+
+# === PROTECT speedrun-specific files (prevent --delete from removing them) ===
+
+# Merge strategy configs
+P .gitattributes
+P packages/nextjs/.gitattributes
+P packages/snfoundry/.gitattributes
+
+# Speedrun UI components and branding
+P packages/nextjs/components/Button/
+P packages/nextjs/components/Button/**
+P packages/nextjs/components/ButtonStyle/
+P packages/nextjs/components/ButtonStyle/**
+P packages/nextjs/components/HeaderLogo.tsx
+P packages/nextjs/components/icons/
+P packages/nextjs/components/icons/**
+
+# Speedrun fonts and assets
+P packages/nextjs/font/
+P packages/nextjs/font/**
+P packages/nextjs/public/icon-starknet.svg
+P packages/nextjs/public/logo-header.svg
+P packages/nextjs/public/speedrunStarknet.svg
+P packages/nextjs/public/starkcompass-icon.svg
+P packages/nextjs/public/Starknet-icon.svg
+P packages/nextjs/public/starknet.svg
+
+# Speedrun-specific contract files
+P packages/snfoundry/contracts/tests/TestContract.cairo
+P packages/snfoundry/scripts-ts/helpers/fees.ts
+
+# Speedrun workflows
+P .github/workflows/sync_other_challenges.yaml
+
+# Editor and dev tool configs
+P .vscode/
+P .vscode/**
+P .claude/
+P .claude/**
+
+# Speedrun project files
+P global_rules.md
+P submissions.md
+
+# === EXCLUDE from sync (never copy these from scaffold-stark-2) ===
+# .git/ is excluded via the workflow's own --exclude flag (kept inline for
+# rebase compatibility with #718's --exclude='.claude/' insertion).
+
+# Test files
+- __test__/
+- __test__/**
+- __tests__/
+- __tests__/**
+
+# Debug and generated assets
+- packages/nextjs/public/debug-image.png
+- packages/nextjs/public/manifest.json
+- packages/nextjs/public/rpc-version.png
+
+# Challenge-specific files (each challenge has its own)
+- packages/snfoundry/contracts/src/your_contract.cairo
+
+# Environment files (speedrunstark has its own credentials)
+- packages/snfoundry/.env
+- packages/nextjs/.env
+
+# Deployment files (speedrunstark has its own deployments)
+- packages/snfoundry/deployments/
+
+# Docs that are rewritten for speedrunstark
+- CHANGELOG*
+- CONTRIBUTING*
+- README.md
+
+# Husky hooks (not used in speedrunstark)
+- .husky/_/
+- .husky/_/**

--- a/.github/workflows/sync-speedrun-repo.yaml
+++ b/.github/workflows/sync-speedrun-repo.yaml
@@ -57,21 +57,18 @@ jobs:
         run: |
           cd speedrun_repo
           git checkout base-challenge-template
-          rsync -av \
-            --exclude='.git/' \
+
+          # Copy filter rules from source repo
+          cp ../source_repo/.github/sync-speedrun-filter-rules /tmp/sync-filter-rules
+
+          rsync -av --delete \
+            --filter='merge /tmp/sync-filter-rules' \
             --include='.github/' \
             --include='.github/workflows/' \
             --include='.github/workflows/main.yml' \
+            --include='.github/sync-speedrun-filter-rules' \
             --exclude='.github/*' \
             --exclude='.github/workflows/*' \
-            --exclude='__test*__' \
-            --exclude='packages/nextjs/public/debug-image.png' \
-            --exclude='packages/nextjs/public/manifest.json' \
-            --exclude='packages/nextjs/public/rpc-version.png' \
-            --exclude='packages/snfoundry/contracts/src/your_contract.cairo' \
-            --exclude='CHANGELOG*' \
-            --exclude='CONTRIBUTING*' \
-            --exclude='README.md' \
             ../source_repo/ ./
 
           # Sync only the Compatible versions section from README.md
@@ -119,9 +116,14 @@ jobs:
           print('Successfully updated Compatible versions section')
           "
 
+          # Only commit and push if there are actual changes
           git add .
-          git commit -m "chore: sync files from scaffold-stark-2 and update Compatible versions section"
-          git push origin base-challenge-template
+          if git diff --cached --quiet; then
+            echo "No changes to sync — skipping commit"
+          else
+            git commit -m "chore: sync files from scaffold-stark-2 and update Compatible versions section"
+            git push origin base-challenge-template
+          fi
 
       - name: Notify Slack on Success
         if: success()

--- a/.github/workflows/sync-speedrun-repo.yaml
+++ b/.github/workflows/sync-speedrun-repo.yaml
@@ -106,22 +106,19 @@ jobs:
           git fetch origin base-challenge-template
           git checkout -B "$TEMP_BRANCH" origin/base-challenge-template
 
-          rsync -av \
+          # Copy filter rules from source repo
+          cp ../source_repo/.github/sync-speedrun-filter-rules /tmp/sync-filter-rules
+
+          rsync -av --delete \
             --exclude='.git/' \
             --exclude='.claude/' \
+            --filter='merge /tmp/sync-filter-rules' \
             --include='.github/' \
             --include='.github/workflows/' \
             --include='.github/workflows/main.yml' \
+            --include='.github/sync-speedrun-filter-rules' \
             --exclude='.github/*' \
             --exclude='.github/workflows/*' \
-            --exclude='__test*__' \
-            --exclude='packages/nextjs/public/debug-image.png' \
-            --exclude='packages/nextjs/public/manifest.json' \
-            --exclude='packages/nextjs/public/rpc-version.png' \
-            --exclude='packages/snfoundry/contracts/src/your_contract.cairo' \
-            --exclude='CHANGELOG*' \
-            --exclude='CONTRIBUTING*' \
-            --exclude='README.md' \
             ../source_repo/ ./
 
           # Sync the Compatible versions section from README.md.


### PR DESCRIPTION
## Summary

- **Add `--delete` flag** to rsync in the speedrun sync workflow so files removed from scaffold-stark-2 are also removed from speedrunstark — this was the root cause of growing drift and manual maintenance
- **Move exclude/protect rules** to a versioned filter file (`.github/sync-speedrun-filter-rules`) instead of inline `--exclude` flags — adding new speedrun-specific files now requires just one line change
- ~~Add empty-commit guard~~ — **already covered by develop's `NOOP` handling** (see Rebase notes below), so this part of the original diff was dropped as redundant

### Context

The basecamp sync workflow already uses `rsync --delete` but speedrunstark did not, causing files deleted from scaffold-stark-2 to persist indefinitely in speedrunstark. This required periodic manual cleanup.

### Filter file structure

```
P <path>   → Protect (never delete from speedrunstark)
- <path>   → Exclude (never copy from scaffold-stark-2)
```

Protected files include speedrun-specific UI components, branding assets, fonts, `.gitattributes` merge strategies, and the challenge sync workflow. Turning on `--delete` without these protect rules would have wiped speedrun-only files (Button/ButtonStyle overrides, logos, fonts, TestContract.cairo, etc.) that don't exist in scaffold-stark-2's tree.

## Rebase notes (2026-07-29)

This PR was opened 2026-03-30 against `main` and went stale. Retargeted to `develop`, which is where all active work lands, and rebased — develop's sync workflow has changed substantially since March (temp-branch + conflict-PR flow, `push`/`workflow_dispatch` triggers, `permissions` block from PRs #710/#711/#714). Reconciled as follows:

- Kept develop's temp-branch/fast-forward/conflict-PR structure intact — only the `rsync` invocation inside the "Sync to temp branch" step changed.
- Added `--delete` and `--filter='merge ...'` (loading `.github/sync-speedrun-filter-rules`) to that rsync call, replacing develop's inline `--exclude` list for files now covered by the filter file (`__test*__`, debug/rpc-version images, `your_contract.cairo`, `CHANGELOG*`, `CONTRIBUTING*`, `README.md`).
- Added `packages/nextjs/public/manifest.json` to the filter file's exclude list — develop excluded it inline and the original PR's filter file didn't, so this was added to avoid a behavior regression.
- Kept the inline `--exclude='.git/'` flag as-is (didn't fold it into the filter file) so it stays a clean anchor line — see note below on #718.
- Dropped the original commit's manual "add . / diff --cached --quiet / commit / push" empty-commit guard — develop's existing `NOOP` check (`if [ -n "$(git status --porcelain)" ]`) in the same step already does this, just against the temp-branch flow instead of a direct push.

### Known follow-on conflict — not resolved here

PR #718 (`crew/workflow-portable`, targets develop, slated to merge before this one) also touches this file, adding `--exclude='.claude/'` right after the existing `--exclude='.git/'` line in the same rsync call. That's why `--exclude='.git/'` was kept inline instead of folded into the filter file — so #718's insertion has a stable context line to apply against. `.claude/` is also already protected via `P .claude/` / `P .claude/**` in the filter file (belt-and-suspenders until #718's exclude lands and makes that redundant). Expect a short second rebase on this file once #718 merges.
