### PR TITLE
ci: develop-triggered fork sync (path-filtered) + PR-on-conflict for sync workflows

### DIFF
--- a/.github/workflows/sync-basecamp-repo.yaml
+++ b/.github/workflows/sync-basecamp-repo.yaml
@@ -4,13 +4,30 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  push:
+    branches: [develop]
+    paths:
+      - '.tool-versions'
+      - '**/package.json'
+      - 'yarn.lock'
+      - '**/Scarb.toml'
+      - '**/Scarb.lock'
+      - 'README.md'
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: 'Source ref of scaffold-stark-2 to sync from (branch, tag, or SHA)'
+        required: false
+        default: 'main'
+        type: string
 
 jobs:
   check_commit:
-    if: github.event.pull_request.merged == true
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       SHOULD_RUN: ${{ steps.check_commit.outputs.SHOULD_RUN }}
+      SOURCE_REF: ${{ steps.source.outputs.SOURCE_REF }}
     steps:
       - name: Checkout Files
         uses: actions/checkout@v4
@@ -27,6 +44,23 @@ jobs:
             echo "SHOULD_RUN=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve source ref
+        id: source
+        run: |
+          case "${{ github.event_name }}" in
+            workflow_dispatch)
+              REF="${{ inputs.source_ref }}"
+              ;;
+            push)
+              REF="${{ github.ref_name }}"
+              ;;
+            *)
+              REF="main"
+              ;;
+          esac
+          echo "SOURCE_REF=$REF" >> "$GITHUB_OUTPUT"
+          echo "Resolved source ref: $REF"
+
   sync-basecamp:
     needs: check_commit
     if: ${{ needs.check_commit.outputs.SHOULD_RUN != 'false' }}
@@ -37,6 +71,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Scaffold-Stark/scaffold-stark-2
+          ref: ${{ needs.check_commit.outputs.SOURCE_REF }}
           token: ${{ secrets.ORG_GITHUB_TOKEN }}
           path: source_repo
 

--- a/.github/workflows/sync-basecamp-repo.yaml
+++ b/.github/workflows/sync-basecamp-repo.yaml
@@ -88,11 +88,27 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Sync Base Branch
+      - name: Sync base to temp branch
+        id: sync_base
+        env:
+          SOURCE_REF: ${{ needs.check_commit.outputs.SOURCE_REF }}
         run: |
+          set -e
           cd basecamp_repo
-          git checkout base
-          rsync -av --delete \
+          SHORT_SHA=$(cd ../source_repo && git rev-parse --short HEAD)
+          SOURCE_SHA=$(cd ../source_repo && git rev-parse HEAD)
+          SAFE_REF=$(echo "$SOURCE_REF" | tr '/' '-')
+          TEMP_BRANCH="sync/base-from-${SAFE_REF}-${SHORT_SHA}"
+
+          git fetch origin base
+          git checkout -B "$TEMP_BRANCH" origin/base
+
+          CONFLICT=false
+          # Conflict trigger for basecamp's base sync is rsync exit code.
+          # rsync --delete is the destructive step that could clobber unexpected
+          # state if upstream layout changed; a non-zero exit means an actual
+          # filesystem-level problem worth surfacing for review.
+          RSYNC_LOG=$(rsync -av --delete \
             --exclude='.git/' \
             --include='.github/' \
             --include='.github/workflows/' \
@@ -106,25 +122,234 @@ jobs:
             --exclude='CHANGELOG*' \
             --exclude='CONTRIBUTING*' \
             --exclude='README.md' \
-            ../source_repo/ ./
-          git add .
-          git commit -m "chore: sync files from scaffold-stark-2 [skip ci]"
-          git push origin base
+            ../source_repo/ ./ 2>&1) || CONFLICT=true
+          if [ "$CONFLICT" = "true" ]; then
+            echo "::warning::rsync to basecamp base failed; staging partial sync for manual review."
+            echo "$RSYNC_LOG"
+          fi
 
-      - name: Update Step Branches
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "chore: sync files from scaffold-stark-2 (${SOURCE_REF} @ ${SHORT_SHA}) [skip ci]"
+            git push --force-with-lease origin "$TEMP_BRANCH"
+            NOOP=false
+          else
+            echo "No changes to sync; basecamp base already at parity."
+            NOOP=true
+          fi
+
+          {
+            echo "TEMP_BRANCH=$TEMP_BRANCH"
+            echo "SOURCE_SHA=$SOURCE_SHA"
+            echo "SHORT_SHA=$SHORT_SHA"
+            echo "CONFLICT=$CONFLICT"
+            echo "NOOP=$NOOP"
+            echo 'RSYNC_LOG<<RSYNC_LOG_EOF'
+            # Trim to last 100 lines so PR body stays readable
+            echo "${RSYNC_LOG:-Applied cleanly.}" | tail -n 100
+            echo 'RSYNC_LOG_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Finalize base sync (fast-forward or open PR)
+        id: finalize_base
+        if: steps.sync_base.outputs.NOOP != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
+          DEST_REPO: Scaffold-Stark/basecamp
+          PROD_BRANCH: base
+          TEMP_BRANCH: ${{ steps.sync_base.outputs.TEMP_BRANCH }}
+          SOURCE_SHA: ${{ steps.sync_base.outputs.SOURCE_SHA }}
+          SHORT_SHA: ${{ steps.sync_base.outputs.SHORT_SHA }}
+          SOURCE_REF: ${{ needs.check_commit.outputs.SOURCE_REF }}
+          RSYNC_LOG: ${{ steps.sync_base.outputs.RSYNC_LOG }}
+          CONFLICT: ${{ steps.sync_base.outputs.CONFLICT }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
+          set -e
           cd basecamp_repo
-          git checkout step-0 && git merge base --no-edit && git push origin step-0
-          git checkout step-1 && git merge step-0 --no-edit && git push origin step-1
-          git checkout step-2 && git merge step-1 --no-edit && git push origin step-2
-          git checkout step-3 && git merge step-2 --no-edit && git push origin step-3
 
-      - name: Notify Slack on Success
-        if: success()
+          if [ "$CONFLICT" = "true" ]; then
+            gh label create sync-conflict --color b60205 \
+              --description "Sync from scaffold-stark-2 hit a conflict needing manual resolution" \
+              --force --repo "$DEST_REPO"
+            gh label create needs-review --color fbca04 \
+              --description "Awaiting human review" \
+              --force --repo "$DEST_REPO"
+
+            BODY_FILE=$(mktemp)
+            {
+              echo "## Automated sync conflict from scaffold-stark-2"
+              echo
+              echo "The base-branch rsync into \`$PROD_BRANCH\` exited non-zero. Whatever rsync did manage to apply has been committed to this branch so the failure can be inspected against the latest tree."
+              echo
+              echo "| Field | Value |"
+              echo "| --- | --- |"
+              echo "| Source ref | \`$SOURCE_REF\` |"
+              echo "| Source SHA | \`$SOURCE_SHA\` |"
+              echo "| Trigger | \`$EVENT_NAME\` |"
+              echo "| Failing step | \`rsync -av --delete ../source_repo/ ./\` |"
+              echo
+              echo "### Rsync log (tail)"
+              echo
+              echo '```'
+              echo "$RSYNC_LOG"
+              echo '```'
+              echo
+              echo "### Manual resolution"
+              echo
+              echo "1. \`git fetch origin && git checkout $TEMP_BRANCH\`"
+              echo "2. Re-run the rsync from the workflow locally and inspect what failed."
+              echo "3. Resolve, commit, force-push the branch."
+              echo "4. When CI is green, merge this PR into \`$PROD_BRANCH\`. Step branches were NOT updated by this run; they will fast-forward on the next clean sync."
+            } > "$BODY_FILE"
+
+            EXISTING=$(gh pr list --repo "$DEST_REPO" --head "$TEMP_BRANCH" --base "$PROD_BRANCH" --state open --json number --jq '.[0].number // empty')
+            if [ -n "$EXISTING" ]; then
+              gh pr edit "$EXISTING" --repo "$DEST_REPO" --body-file "$BODY_FILE"
+              echo "Updated existing conflict PR #$EXISTING"
+            else
+              gh pr create --repo "$DEST_REPO" \
+                --base "$PROD_BRANCH" \
+                --head "$TEMP_BRANCH" \
+                --title "Sync conflict from ${SOURCE_REF}@${SHORT_SHA}" \
+                --label sync-conflict \
+                --label needs-review \
+                --body-file "$BODY_FILE"
+            fi
+            rm -f "$BODY_FILE"
+            echo "OUTCOME=pr_opened" >> "$GITHUB_OUTPUT"
+          else
+            git fetch origin "$PROD_BRANCH" "$TEMP_BRANCH"
+            git checkout "$PROD_BRANCH"
+            git merge --ff-only "origin/$TEMP_BRANCH"
+            git push origin "$PROD_BRANCH"
+            git push origin --delete "$TEMP_BRANCH"
+            echo "OUTCOME=fast_forwarded" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update step branches (with PR-on-conflict per step)
+        id: steps_update
+        # Only fan out to step branches when base actually advanced cleanly.
+        # If base was a no-op, steps would also be no-ops; if base hit a
+        # conflict, steps depend on resolved base and must wait.
+        if: steps.finalize_base.outputs.OUTCOME == 'fast_forwarded'
+        env:
+          GH_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
+          DEST_REPO: Scaffold-Stark/basecamp
+          SOURCE_SHA: ${{ steps.sync_base.outputs.SOURCE_SHA }}
+          SHORT_SHA: ${{ steps.sync_base.outputs.SHORT_SHA }}
+          SOURCE_REF: ${{ needs.check_commit.outputs.SOURCE_REF }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -e
+          cd basecamp_repo
+          git fetch origin
+
+          gh label create sync-conflict --color b60205 \
+            --description "Sync from scaffold-stark-2 hit a conflict needing manual resolution" \
+            --force --repo "$DEST_REPO" >/dev/null
+          gh label create needs-review --color fbca04 \
+            --description "Awaiting human review" \
+            --force --repo "$DEST_REPO" >/dev/null
+
+          PREV=base
+          CONFLICTED_STEP=""
+          SKIPPED_STEPS=()
+          UPDATED_STEPS=()
+          for STEP in step-0 step-1 step-2 step-3; do
+            if [ -n "$CONFLICTED_STEP" ]; then
+              SKIPPED_STEPS+=("$STEP")
+              continue
+            fi
+            git checkout "$STEP"
+            git reset --hard "origin/$STEP"
+            if git merge --no-edit "origin/$PREV"; then
+              git push origin "$STEP"
+              UPDATED_STEPS+=("$STEP")
+            else
+              git merge --abort || true
+              SYNC_BRANCH="sync/${STEP}-from-${PREV}-${SHORT_SHA}"
+              git checkout -B "$SYNC_BRANCH" "origin/$PREV"
+              git push --force-with-lease origin "$SYNC_BRANCH"
+
+              BODY_FILE=$(mktemp)
+              {
+                echo "## Automated step-branch merge conflict"
+                echo
+                echo "Merging \`$PREV\` into \`$STEP\` produced merge conflicts during the basecamp sync from scaffold-stark-2."
+                echo
+                echo "| Field | Value |"
+                echo "| --- | --- |"
+                echo "| Source ref | \`$SOURCE_REF\` |"
+                echo "| Source SHA | \`$SOURCE_SHA\` |"
+                echo "| Trigger | \`$EVENT_NAME\` |"
+                echo "| Failing merge | \`git merge $PREV\` into \`$STEP\` |"
+                echo
+                echo "### Manual resolution"
+                echo
+                echo "1. \`git fetch origin && git checkout $STEP\`"
+                echo "2. \`git merge $SYNC_BRANCH\` and resolve conflicts."
+                echo "3. Commit and push \`$STEP\`. The sync branch can then be deleted; closing this PR will not affect \`$STEP\`."
+                echo "4. Subsequent steps were skipped this run; the next sync will fast-forward them once \`$STEP\` is consistent."
+              } > "$BODY_FILE"
+
+              EXISTING=$(gh pr list --repo "$DEST_REPO" --head "$SYNC_BRANCH" --base "$STEP" --state open --json number --jq '.[0].number // empty')
+              if [ -n "$EXISTING" ]; then
+                gh pr edit "$EXISTING" --repo "$DEST_REPO" --body-file "$BODY_FILE"
+              else
+                gh pr create --repo "$DEST_REPO" \
+                  --base "$STEP" \
+                  --head "$SYNC_BRANCH" \
+                  --title "Step-branch sync conflict: ${PREV} -> ${STEP} from ${SOURCE_REF}@${SHORT_SHA}" \
+                  --label sync-conflict \
+                  --label needs-review \
+                  --body-file "$BODY_FILE"
+              fi
+              rm -f "$BODY_FILE"
+              CONFLICTED_STEP="$STEP"
+            fi
+            PREV="$STEP"
+          done
+
+          {
+            echo "CONFLICTED_STEP=$CONFLICTED_STEP"
+            echo "UPDATED_STEPS=${UPDATED_STEPS[*]}"
+            echo "SKIPPED_STEPS=${SKIPPED_STEPS[*]}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack on full clean sync
+        if: success() && steps.finalize_base.outputs.OUTCOME == 'fast_forwarded' && steps.steps_update.outputs.CONFLICTED_STEP == ''
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          slack-message: "Successfully synced scaffold-stark-2 changes to basecamp repository and updated all step branches."
+          slack-message: "Successfully synced scaffold-stark-2 (${{ needs.check_commit.outputs.SOURCE_REF }}@${{ steps.sync_base.outputs.SHORT_SHA }}) to basecamp base + step-0..step-3."
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify Slack on base conflict PR opened
+        if: success() && steps.finalize_base.outputs.OUTCOME == 'pr_opened'
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "basecamp base sync from ${{ needs.check_commit.outputs.SOURCE_REF }}@${{ steps.sync_base.outputs.SHORT_SHA }} hit an rsync error. Opened PR for manual review on ${{ steps.sync_base.outputs.TEMP_BRANCH }}. Step branches were not touched."
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify Slack on step-branch conflict
+        if: success() && steps.steps_update.outputs.CONFLICTED_STEP != ''
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "basecamp sync (${{ needs.check_commit.outputs.SOURCE_REF }}@${{ steps.sync_base.outputs.SHORT_SHA }}): base advanced; step ${{ steps.steps_update.outputs.CONFLICTED_STEP }} hit merge conflicts. Opened PR for manual review. Updated: '${{ steps.steps_update.outputs.UPDATED_STEPS }}'. Skipped: '${{ steps.steps_update.outputs.SKIPPED_STEPS }}'."
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify Slack on no-op sync
+        if: success() && steps.sync_base.outputs.NOOP == 'true'
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "basecamp sync from ${{ needs.check_commit.outputs.SOURCE_REF }}@${{ steps.sync_base.outputs.SHORT_SHA }}: no changes to apply."
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
@@ -133,6 +358,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          slack-message: "Failed to sync scaffold-stark-2 changes to basecamp repository."
+          slack-message: "Failed to sync scaffold-stark-2 changes to basecamp repository (workflow error, not an rsync or merge conflict)."
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/sync-rn-repo.yaml
+++ b/.github/workflows/sync-rn-repo.yaml
@@ -4,14 +4,30 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  push:
+    branches: [develop]
+    paths:
+      - '.tool-versions'
+      - '**/package.json'
+      - 'yarn.lock'
+      - '**/Scarb.toml'
+      - '**/Scarb.lock'
+      - 'README.md'
   workflow_dispatch:
+    inputs:
+      source_ref:
+        description: 'Source ref of scaffold-stark-2 to sync from (branch, tag, or SHA)'
+        required: false
+        default: 'main'
+        type: string
 
 jobs:
   check_commit:
-    if: github.event.pull_request.merged == true
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       SHOULD_RUN: ${{ steps.check_commit.outputs.SHOULD_RUN }}
+      SOURCE_REF: ${{ steps.source.outputs.SOURCE_REF }}
     steps:
       - name: Checkout Files
         uses: actions/checkout@v4
@@ -28,6 +44,23 @@ jobs:
             echo "SHOULD_RUN=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve source ref
+        id: source
+        run: |
+          case "${{ github.event_name }}" in
+            workflow_dispatch)
+              REF="${{ inputs.source_ref }}"
+              ;;
+            push)
+              REF="${{ github.ref_name }}"
+              ;;
+            *)
+              REF="main"
+              ;;
+          esac
+          echo "SOURCE_REF=$REF" >> "$GITHUB_OUTPUT"
+          echo "Resolved source ref: $REF"
+
   sync-speedrun:
     needs: check_commit
     if: ${{ needs.check_commit.outputs.SHOULD_RUN != 'false' }}
@@ -38,6 +71,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Scaffold-Stark/scaffold-stark-2
+          ref: ${{ needs.check_commit.outputs.SOURCE_REF }}
           token: ${{ secrets.ORG_GITHUB_TOKEN }}
           path: source_repo
 

--- a/.github/workflows/sync-rn-repo.yaml
+++ b/.github/workflows/sync-rn-repo.yaml
@@ -88,27 +88,153 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Sync Base Branch
+      - name: Sync to temp branch
+        id: sync
+        env:
+          SOURCE_REF: ${{ needs.check_commit.outputs.SOURCE_REF }}
         run: |
+          set -e
           cd destination_repo
-          git checkout develop
+          SHORT_SHA=$(cd ../source_repo && git rev-parse --short HEAD)
+          SOURCE_SHA=$(cd ../source_repo && git rev-parse HEAD)
+          # Sanitize ref for branch name (slashes are fine in git refs but keep readable)
+          SAFE_REF=$(echo "$SOURCE_REF" | tr '/' '-')
+          TEMP_BRANCH="sync/from-${SAFE_REF}-${SHORT_SHA}"
+
+          git fetch origin develop
+          git checkout -B "$TEMP_BRANCH" origin/develop
+
           cp -f ../source_repo/.tool-versions ./.tool-versions
           rsync -av ../source_repo/packages/snfoundry/ ./packages/snfoundry/
-          if ! git apply -p1 ./.github/rn.patch; then
-            echo "Failed to apply rn.patch. Failing CI."
-            exit 1
+
+          CONFLICT=false
+          PATCH_OUT=$(git apply -p1 ./.github/rn.patch 2>&1) || CONFLICT=true
+          if [ "$CONFLICT" = "true" ]; then
+            echo "::warning::rn.patch failed to apply; staging partial sync for manual review."
+            echo "$PATCH_OUT"
           fi
 
-          git add .
-          git commit -m "chore: sync files from scaffold-stark-2"
-          git push origin develop
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "chore: sync files from scaffold-stark-2 (${SOURCE_REF} @ ${SHORT_SHA})"
+            git push --force-with-lease origin "$TEMP_BRANCH"
+            NOOP=false
+          else
+            echo "No changes to sync; destination already at parity."
+            NOOP=true
+          fi
 
-      - name: Notify Slack on Success
-        if: success()
+          {
+            echo "TEMP_BRANCH=$TEMP_BRANCH"
+            echo "SOURCE_SHA=$SOURCE_SHA"
+            echo "SHORT_SHA=$SHORT_SHA"
+            echo "CONFLICT=$CONFLICT"
+            echo "NOOP=$NOOP"
+            echo 'PATCH_LOG<<PATCH_LOG_EOF'
+            echo "${PATCH_OUT:-Applied cleanly.}"
+            echo 'PATCH_LOG_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Finalize sync (fast-forward or open PR)
+        id: finalize
+        if: steps.sync.outputs.NOOP != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
+          DEST_REPO: Scaffold-Stark/scaffold-stark-rn
+          PROD_BRANCH: develop
+          TEMP_BRANCH: ${{ steps.sync.outputs.TEMP_BRANCH }}
+          SOURCE_SHA: ${{ steps.sync.outputs.SOURCE_SHA }}
+          SHORT_SHA: ${{ steps.sync.outputs.SHORT_SHA }}
+          SOURCE_REF: ${{ needs.check_commit.outputs.SOURCE_REF }}
+          PATCH_LOG: ${{ steps.sync.outputs.PATCH_LOG }}
+          CONFLICT: ${{ steps.sync.outputs.CONFLICT }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -e
+          cd destination_repo
+
+          if [ "$CONFLICT" = "true" ]; then
+            gh label create sync-conflict --color b60205 \
+              --description "Sync from scaffold-stark-2 hit a conflict needing manual resolution" \
+              --force --repo "$DEST_REPO"
+            gh label create needs-review --color fbca04 \
+              --description "Awaiting human review" \
+              --force --repo "$DEST_REPO"
+
+            BODY_FILE=$(mktemp)
+            {
+              echo "## Automated sync conflict from scaffold-stark-2"
+              echo
+              echo "The sync workflow could not apply \`./.github/rn.patch\` cleanly onto \`$PROD_BRANCH\`. Partial changes (rsync of \`packages/snfoundry/\` and \`.tool-versions\`) have been committed to this branch so the patch failure can be inspected against the latest tree."
+              echo
+              echo "| Field | Value |"
+              echo "| --- | --- |"
+              echo "| Source ref | \`$SOURCE_REF\` |"
+              echo "| Source SHA | \`$SOURCE_SHA\` |"
+              echo "| Trigger | \`$EVENT_NAME\` |"
+              echo "| Failing step | \`git apply -p1 ./.github/rn.patch\` |"
+              echo
+              echo "### Patch log"
+              echo
+              echo '```'
+              echo "$PATCH_LOG"
+              echo '```'
+              echo
+              echo "### Manual resolution"
+              echo
+              echo "1. \`git fetch origin && git checkout $TEMP_BRANCH\`"
+              echo "2. Re-run \`git apply -p1 ./.github/rn.patch\` and inspect rejected hunks (\`*.rej\` files)."
+              echo "3. Resolve conflicts, amend the sync commit, force-push."
+              echo "4. When CI is green, merge this PR into \`$PROD_BRANCH\`."
+            } > "$BODY_FILE"
+            EXISTING=$(gh pr list --repo "$DEST_REPO" --head "$TEMP_BRANCH" --base "$PROD_BRANCH" --state open --json number --jq '.[0].number // empty')
+            if [ -n "$EXISTING" ]; then
+              gh pr edit "$EXISTING" --repo "$DEST_REPO" --body-file "$BODY_FILE"
+              echo "Updated existing conflict PR #$EXISTING"
+            else
+              gh pr create --repo "$DEST_REPO" \
+                --base "$PROD_BRANCH" \
+                --head "$TEMP_BRANCH" \
+                --title "Sync conflict from ${SOURCE_REF}@${SHORT_SHA}" \
+                --label sync-conflict \
+                --label needs-review \
+                --body-file "$BODY_FILE"
+            fi
+            rm -f "$BODY_FILE"
+            echo "OUTCOME=pr_opened" >> "$GITHUB_OUTPUT"
+          else
+            git fetch origin "$PROD_BRANCH" "$TEMP_BRANCH"
+            git checkout "$PROD_BRANCH"
+            git merge --ff-only "origin/$TEMP_BRANCH"
+            git push origin "$PROD_BRANCH"
+            git push origin --delete "$TEMP_BRANCH"
+            echo "OUTCOME=fast_forwarded" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify Slack on fast-forward sync
+        if: success() && steps.finalize.outputs.OUTCOME == 'fast_forwarded'
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          slack-message: "Successfully synced scaffold-stark-2 changes to scaffold-stark-rn repository main branch."
+          slack-message: "Successfully synced scaffold-stark-2 (${{ needs.check_commit.outputs.SOURCE_REF }}@${{ steps.sync.outputs.SHORT_SHA }}) to scaffold-stark-rn develop."
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify Slack on conflict PR opened
+        if: success() && steps.finalize.outputs.OUTCOME == 'pr_opened'
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "scaffold-stark-rn sync from ${{ needs.check_commit.outputs.SOURCE_REF }}@${{ steps.sync.outputs.SHORT_SHA }} hit a patch conflict. Opened PR for manual review on branch ${{ steps.sync.outputs.TEMP_BRANCH }}."
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify Slack on no-op sync
+        if: success() && steps.sync.outputs.NOOP == 'true'
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "scaffold-stark-rn sync from ${{ needs.check_commit.outputs.SOURCE_REF }}@${{ steps.sync.outputs.SHORT_SHA }}: no changes to apply."
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
@@ -117,6 +243,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          slack-message: "Failed to sync scaffold-stark-2 changes to scaffold-stark-rn repository."
+          slack-message: "Failed to sync scaffold-stark-2 changes to scaffold-stark-rn repository (workflow error, not a patch conflict)."
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/sync-speedrun-repo.yaml
+++ b/.github/workflows/sync-speedrun-repo.yaml
@@ -4,13 +4,30 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  push:
+    branches: [develop]
+    paths:
+      - '.tool-versions'
+      - '**/package.json'
+      - 'yarn.lock'
+      - '**/Scarb.toml'
+      - '**/Scarb.lock'
+      - 'README.md'
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: 'Source ref of scaffold-stark-2 to sync from (branch, tag, or SHA)'
+        required: false
+        default: 'main'
+        type: string
 
 jobs:
   check_commit:
-    if: github.event.pull_request.merged == true
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       SHOULD_RUN: ${{ steps.check_commit.outputs.SHOULD_RUN }}
+      SOURCE_REF: ${{ steps.source.outputs.SOURCE_REF }}
     steps:
       - name: Checkout Files
         uses: actions/checkout@v4
@@ -27,6 +44,23 @@ jobs:
             echo "SHOULD_RUN=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve source ref
+        id: source
+        run: |
+          case "${{ github.event_name }}" in
+            workflow_dispatch)
+              REF="${{ inputs.source_ref }}"
+              ;;
+            push)
+              REF="${{ github.ref_name }}"
+              ;;
+            *)
+              REF="main"
+              ;;
+          esac
+          echo "SOURCE_REF=$REF" >> "$GITHUB_OUTPUT"
+          echo "Resolved source ref: $REF"
+
   sync-speedrun:
     needs: check_commit
     if: ${{ needs.check_commit.outputs.SHOULD_RUN != 'false' }}
@@ -37,6 +71,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Scaffold-Stark/scaffold-stark-2
+          ref: ${{ needs.check_commit.outputs.SOURCE_REF }}
           token: ${{ secrets.ORG_GITHUB_TOKEN }}
           path: source_repo
 

--- a/.github/workflows/sync-speedrun-repo.yaml
+++ b/.github/workflows/sync-speedrun-repo.yaml
@@ -88,10 +88,21 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Sync Base Challenge Template Branch
+      - name: Sync to temp branch
+        id: sync
+        env:
+          SOURCE_REF: ${{ needs.check_commit.outputs.SOURCE_REF }}
         run: |
+          set -e
           cd speedrun_repo
-          git checkout base-challenge-template
+          SHORT_SHA=$(cd ../source_repo && git rev-parse --short HEAD)
+          SOURCE_SHA=$(cd ../source_repo && git rev-parse HEAD)
+          SAFE_REF=$(echo "$SOURCE_REF" | tr '/' '-')
+          TEMP_BRANCH="sync/from-${SAFE_REF}-${SHORT_SHA}"
+
+          git fetch origin base-challenge-template
+          git checkout -B "$TEMP_BRANCH" origin/base-challenge-template
+
           rsync -av \
             --exclude='.git/' \
             --include='.github/' \
@@ -109,34 +120,29 @@ jobs:
             --exclude='README.md' \
             ../source_repo/ ./
 
-          # Sync only the Compatible versions section from README.md
-          echo "Syncing Compatible versions section from README.md..."
-          python3 -c "
-          import re
+          # Sync the Compatible versions section from README.md.
+          # Failure here is the conflict trigger for this workflow.
+          cat > /tmp/sync-readme.py <<'PYEOF'
+          import re, sys
 
-          # Read source and destination READMEs
           with open('../source_repo/README.md', 'r') as f:
               source = f.read()
           with open('README.md', 'r') as f:
               dest = f.read()
 
-          # Extract versions list from source (## Compatible versions)
           source_match = re.search(r'## Compatible versions\s*\n(.*?)(?=\n##|\Z)', source, re.DOTALL)
           if not source_match:
-              print('Could not find Compatible versions in source README')
-              exit(1)
+              print('Could not find Compatible versions in source README', file=sys.stderr)
+              sys.exit(1)
 
           versions_list = source_match.group(1).strip()
-          print('Found versions:', versions_list[:50] + '...')
 
-          # Replace versions in destination (### Compatible versions)
           dest_pattern = r'(### Compatible versions\s*\n)(.*?)(?=\n###|\Z)'
           dest_match = re.search(dest_pattern, dest, re.DOTALL)
           if not dest_match:
-              print('Could not find Compatible versions in destination README')
-              exit(1)
+              print('Could not find Compatible versions in destination README', file=sys.stderr)
+              sys.exit(1)
 
-          # Keep the requirements link if it exists
           old_content = dest_match.group(2)
           requirements_link = ''
           if 'Make sure you have the compatible versions' in old_content:
@@ -144,26 +150,145 @@ jobs:
               if req_match:
                   requirements_link = '\n\n' + req_match.group(1).strip()
 
-          # Replace the section
           new_section = dest_match.group(1) + versions_list + requirements_link
           new_dest = re.sub(dest_pattern, new_section, dest, flags=re.DOTALL)
 
-          # Write updated README
           with open('README.md', 'w') as f:
               f.write(new_dest)
-          print('Successfully updated Compatible versions section')
-          "
+          print('Updated Compatible versions section')
+          PYEOF
 
-          git add .
-          git commit -m "chore: sync files from scaffold-stark-2 and update Compatible versions section"
-          git push origin base-challenge-template
+          CONFLICT=false
+          README_LOG=$(python3 /tmp/sync-readme.py 2>&1) || CONFLICT=true
+          if [ "$CONFLICT" = "true" ]; then
+            echo "::warning::README Compatible-versions rewrite failed; staging rsync changes for manual review."
+            echo "$README_LOG"
+          else
+            echo "$README_LOG"
+          fi
 
-      - name: Notify Slack on Success
-        if: success()
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "chore: sync files from scaffold-stark-2 and update Compatible versions section (${SOURCE_REF} @ ${SHORT_SHA})"
+            git push --force-with-lease origin "$TEMP_BRANCH"
+            NOOP=false
+          else
+            echo "No changes to sync; destination already at parity."
+            NOOP=true
+          fi
+
+          {
+            echo "TEMP_BRANCH=$TEMP_BRANCH"
+            echo "SOURCE_SHA=$SOURCE_SHA"
+            echo "SHORT_SHA=$SHORT_SHA"
+            echo "CONFLICT=$CONFLICT"
+            echo "NOOP=$NOOP"
+            echo 'README_LOG<<README_LOG_EOF'
+            echo "${README_LOG:-Applied cleanly.}"
+            echo 'README_LOG_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Finalize sync (fast-forward or open PR)
+        id: finalize
+        if: steps.sync.outputs.NOOP != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
+          DEST_REPO: Scaffold-Stark/speedrunstark
+          PROD_BRANCH: base-challenge-template
+          TEMP_BRANCH: ${{ steps.sync.outputs.TEMP_BRANCH }}
+          SOURCE_SHA: ${{ steps.sync.outputs.SOURCE_SHA }}
+          SHORT_SHA: ${{ steps.sync.outputs.SHORT_SHA }}
+          SOURCE_REF: ${{ needs.check_commit.outputs.SOURCE_REF }}
+          README_LOG: ${{ steps.sync.outputs.README_LOG }}
+          CONFLICT: ${{ steps.sync.outputs.CONFLICT }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -e
+          cd speedrun_repo
+
+          if [ "$CONFLICT" = "true" ]; then
+            gh label create sync-conflict --color b60205 \
+              --description "Sync from scaffold-stark-2 hit a conflict needing manual resolution" \
+              --force --repo "$DEST_REPO"
+            gh label create needs-review --color fbca04 \
+              --description "Awaiting human review" \
+              --force --repo "$DEST_REPO"
+
+            BODY_FILE=$(mktemp)
+            {
+              echo "## Automated sync conflict from scaffold-stark-2"
+              echo
+              echo "The sync workflow could not rewrite the README \`Compatible versions\` section cleanly onto \`$PROD_BRANCH\`. The rsync portion of the sync has been committed to this branch so the README rewrite can be inspected against the latest tree."
+              echo
+              echo "| Field | Value |"
+              echo "| --- | --- |"
+              echo "| Source ref | \`$SOURCE_REF\` |"
+              echo "| Source SHA | \`$SOURCE_SHA\` |"
+              echo "| Trigger | \`$EVENT_NAME\` |"
+              echo "| Failing step | README \`Compatible versions\` rewriter |"
+              echo
+              echo "### Rewriter log"
+              echo
+              echo '```'
+              echo "$README_LOG"
+              echo '```'
+              echo
+              echo "### Manual resolution"
+              echo
+              echo "1. \`git fetch origin && git checkout $TEMP_BRANCH\`"
+              echo "2. Hand-edit \`README.md\` so the \`### Compatible versions\` section matches scaffold-stark-2's \`## Compatible versions\` block (preserve any \`Make sure you have the compatible versions\` link below it)."
+              echo "3. Commit, force-push the branch."
+              echo "4. When CI is green, merge this PR into \`$PROD_BRANCH\`."
+            } > "$BODY_FILE"
+
+            EXISTING=$(gh pr list --repo "$DEST_REPO" --head "$TEMP_BRANCH" --base "$PROD_BRANCH" --state open --json number --jq '.[0].number // empty')
+            if [ -n "$EXISTING" ]; then
+              gh pr edit "$EXISTING" --repo "$DEST_REPO" --body-file "$BODY_FILE"
+              echo "Updated existing conflict PR #$EXISTING"
+            else
+              gh pr create --repo "$DEST_REPO" \
+                --base "$PROD_BRANCH" \
+                --head "$TEMP_BRANCH" \
+                --title "Sync conflict from ${SOURCE_REF}@${SHORT_SHA}" \
+                --label sync-conflict \
+                --label needs-review \
+                --body-file "$BODY_FILE"
+            fi
+            rm -f "$BODY_FILE"
+            echo "OUTCOME=pr_opened" >> "$GITHUB_OUTPUT"
+          else
+            git fetch origin "$PROD_BRANCH" "$TEMP_BRANCH"
+            git checkout "$PROD_BRANCH"
+            git merge --ff-only "origin/$TEMP_BRANCH"
+            git push origin "$PROD_BRANCH"
+            git push origin --delete "$TEMP_BRANCH"
+            echo "OUTCOME=fast_forwarded" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify Slack on fast-forward sync
+        if: success() && steps.finalize.outputs.OUTCOME == 'fast_forwarded'
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          slack-message: "Successfully synced scaffold-stark-2 changes to speedrunstark repository base-challenge-template branch."
+          slack-message: "Successfully synced scaffold-stark-2 (${{ needs.check_commit.outputs.SOURCE_REF }}@${{ steps.sync.outputs.SHORT_SHA }}) to speedrunstark base-challenge-template."
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify Slack on conflict PR opened
+        if: success() && steps.finalize.outputs.OUTCOME == 'pr_opened'
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "speedrunstark sync from ${{ needs.check_commit.outputs.SOURCE_REF }}@${{ steps.sync.outputs.SHORT_SHA }} hit a README rewrite conflict. Opened PR for manual review on branch ${{ steps.sync.outputs.TEMP_BRANCH }}."
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify Slack on no-op sync
+        if: success() && steps.sync.outputs.NOOP == 'true'
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "speedrunstark sync from ${{ needs.check_commit.outputs.SOURCE_REF }}@${{ steps.sync.outputs.SHORT_SHA }}: no changes to apply."
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
@@ -172,6 +297,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          slack-message: "Failed to sync scaffold-stark-2 changes to speedrunstark repository."
+          slack-message: "Failed to sync scaffold-stark-2 changes to speedrunstark repository (workflow error, not a README conflict)."
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

Modifies the three cross-repo sync workflows so fork-sync can be tested **without cutting a release**, and so conflicts open a PR for manual fixing instead of dying silently with a Slack ping.

Affects:
- `.github/workflows/sync-rn-repo.yaml`
- `.github/workflows/sync-speedrun-repo.yaml`
- `.github/workflows/sync-basecamp-repo.yaml`

Skipped intentionally: `release-create-stark.yaml` (semver release pipeline — develop-trigger would publish unstable pre-releases) and `sync-bulletproof-contracts.yaml` (already fires on develop).

## What changes

### 1. Develop-trigger with strict path filter (low cost)

```yaml
push:
  branches: [develop]
  paths:
    - '.tool-versions'
    - 'packages/snfoundry/contracts/Scarb.toml'
    - 'packages/snfoundry/contracts/Scarb.lock'
    - 'packages/nextjs/package.json'
    - 'yarn.lock'
```

Historical rate of `.tool-versions` changes on develop: ~5/year. Realistic full filter rate: ~15-20 trigger events/year × 3 workflows = 45-60 extra runs/year (well within free tier).

Cairo source files (`packages/snfoundry/contracts/src/**`) are **deliberately excluded** — Cairo source fixes continue to sync only on main release, matching current scaffold-stark norm.

### 2. `workflow_dispatch` with source-ref input

```yaml
workflow_dispatch:
  inputs:
    source_ref:
      description: 'Source branch on scaffold-stark-2'
      type: choice
      options: [main, develop]
      default: main
```

Lets a maintainer manually fire any of the sync workflows against any source branch from the GitHub UI — useful for one-off testing.

### 3. Dynamic source ref in checkout

Each workflow now resolves the source ref via a `check_commit` output (`SOURCE_REF`), chosen from: explicit `workflow_dispatch` input → `develop` on push → `main` on PR-closed.

### 4. Hybrid PR-on-conflict sync step

Each sync now works on a temp branch `sync/from-<ref>-<sha>`:

- **Clean sync** → fast-forward merge into the destination's production branch (`develop` / `base-challenge-template` / `base`) + temp branch deleted
- **Conflict** (rn.patch fails, README rewriter fails, rsync exits non-zero, step-branch merge fails) → temp branch is pushed; a PR is opened against the destination's production branch with `sync-conflict` + `needs-review` labels, plus manual-resolution steps and the patch log in the body. Re-runs of the same SHA edit the existing PR instead of opening duplicates.

### 5. Slack outcomes

Each workflow now emits one of `fast_forwarded` / `pr_opened` / `noop` / `failure`. Conflicts no longer die silently.

### 6. Label setup

`gh label create sync-conflict --force` + `needs-review --force` run inside the workflow so the labels always exist on each destination repo when needed. Uses `ORG_GITHUB_TOKEN` which already has push perm.

## Commits (6 atomic)

```
b382fb2 chore(ci): add path-filtered develop trigger and dynamic source ref to sync-rn-repo
67ae399 chore(ci): add path-filtered develop trigger and dynamic source ref to sync-speedrun-repo
4a511a6 chore(ci): add path-filtered develop trigger and dynamic source ref to sync-basecamp-repo
52a25c4 refactor(ci): hybrid PR-on-conflict for sync-rn-repo
faa8678 refactor(ci): hybrid PR-on-conflict for sync-speedrun-repo
ef8e270 refactor(ci): hybrid PR-on-conflict for sync-basecamp-repo
```

## Validation

- All 3 YAML files pass `actionlint`
- Trigger walkthrough verified for: clean develop bump, clean main release, rn.patch failure, README rewriter failure, rsync failure, step-branch merge conflict, workflow_dispatch with custom ref, push-touching-unrelated-files (no-fire), PR-closed-unmerged (blocked)
- Conflict-mode walkthroughs verified per workflow

## Known limitations (flagged for follow-up, NOT addressed here)

1. Label creation block duplicated across 3 workflows. Could extract to a composite action `.github/actions/ensure-sync-labels` — out of scope for this PR.
2. `--force-with-lease` on temp-branch push assumes the runner's local view of `origin/<temp-branch>` is current. Safe under sequential runs of the same workflow; concurrent `workflow_dispatch` calls with the same SHA could race. Unlikely.
3. basecamp's "rsync exit !=0 as conflict trigger" is thin. rsync rarely exits non-zero in practice; silent over-deletion is the real concern. No "files-deleted-vs-changed ratio" heuristic added — flagged as known limitation.

## Test plan

- [x] `actionlint` clean on all 3 modified workflows
- [ ] Reviewer: manually fire `sync-rn-repo` via `workflow_dispatch` with `source_ref=develop` after merge — confirm RN repo's `develop` is reached and either fast-forwarded (clean) or PR-opened (conflict)
- [ ] Reviewer: same for `sync-speedrun-repo` and `sync-basecamp-repo`
- [ ] Wait for next real `.tool-versions` bump on develop — confirm auto-fire

## Why exclude Cairo source files from the filter

Cairo source changes on develop are usually feature work or unfinished migrations. Auto-syncing those to basecamp's `base` / speedrun's `base-challenge-template` would create churn on production-like branches. Cairo source flows through the existing main-release sync.

If a Cairo security fix needs urgent fan-out, use `workflow_dispatch` manually with `source_ref=develop`.