### PR TITLE
chore(nextjs): bump caniuse-lite via update-browserslist-db

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6450,9 +6450,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001406, caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001737":
-  version: 1.0.30001741
-  resolution: "caniuse-lite@npm:1.0.30001741"
-  checksum: 0f2e90e1418a0b35923735420a0a0f9d2aa91eb6e0e2ae955e386155b402892ed4aa9996aae644b9f0cf2cf6a2af52c9467d4f8fc1d1710e8e4c961f12bdec67
+  version: 1.0.30001792
+  resolution: "caniuse-lite@npm:1.0.30001792"
+  checksum: 25e2ba0feb792fbc99e98b236653dccec6387bf9351510b5401ffcb0c25193e47a2ba37e5ce44f92e0fb023670fe077b938ab8e1bad53bc03e95673e5bd5d439
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Refreshes the browserslist database to silence the "caniuse-lite is outdated" warning that prints on every `yarn build`. Single transitive bump, no other dep movement.

## Why

Caught during create-stark smoke testing — every scaffolded user inherits the stale caniuse-lite via lockfile sync. Easier to fix at the source.

## Changes

1 commit: `49d51d2 chore(nextjs): bump caniuse-lite via update-browserslist-db`

- `packages/nextjs/yarn.lock` — `caniuse-lite` bumped to current. All three semver ranges (`^1.0.30001406`, `^1.0.30001579`, `^1.0.30001737`) now resolve to a single up-to-date entry.

## Supply-chain verification

- ✅ No suspect families (`@tanstack/router|db|pacer|devtools|config`, Shai-Hulud families, axios 1.14.1/0.30.4, plain-crypto-js)
- ✅ `caniuse-lite@npm:1.0.30001792` resolves with valid checksum
- ✅ Single entry serves all three ranges (no fork)

## Verification

- ✅ `yarn install --immutable`
- ✅ `yarn lint`
- ✅ `yarn check-types`
- ✅ `yarn test`
- ✅ `yarn build` — "Browserslist: caniuse-lite is outdated" warning gone

## Test plan

- [x] yarn build no longer prints browserslist outdated warning
- [ ] Reviewer: confirm production build still compiles clean