### PR TITLE
chore: remove stray scratch files and gitignore local/generated state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ package-lock.json
 
 **/.env*
 !**/.env.example
+
+# local tooling / generated state (keep local, do not commit)
+.claude/
+.gitnexus/

--- a/packages/nextjs/.gitignore
+++ b/packages/nextjs/.gitignore
@@ -35,3 +35,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# next-pwa generated service worker (build output, keep local)
+public/sw.js
+public/workbox-*.js
+public/sw.js.map
+public/workbox-*.js.map


### PR DESCRIPTION
## What

Working-tree hygiene: remove stray scratch artifacts and gitignore local/generated state so they stop showing up as untracked noise.

### Deleted (junk + scratch, archived elsewhere)
- `=2.0.0`, `=2.18.0`, `=3.0.0` — empty (0-byte) npm redirect junk files in repo root
- `audit-cleanup.md`, `audit-infra.md`, `audit-starknet-deps.md`, `fe-verification.md` — scratch audit notes (archived to spoke vault)
- `fe-verify-screenshots/` — directory of scratch verification screenshots

### Gitignored (kept local, not deleted)
- root `.gitignore`: `.claude/`, `.gitnexus/` — local tooling state
- `packages/nextjs/.gitignore`: `public/sw.js`, `public/workbox-*.js`, `public/sw.js.map`, `public/workbox-*.js.map` — next-pwa build outputs

## Verification
- `git status` clean except the two `.gitignore` changes
- `git check-ignore` confirms all formerly-untracked local/generated paths now resolve to an ignore rule
- pre-commit prettier `format:check` passed

Only `.gitignore` files are modified; no source/code changes.