### PR TITLE
fix(ci): add verify-contracts.ts nextjs/contracts rewrite to sync-rn-repo (parity with parse-deployments)

### DIFF
--- a/.github/workflows/sync-rn-repo.yaml
+++ b/.github/workflows/sync-rn-repo.yaml
@@ -114,6 +114,7 @@ jobs:
           REASON=""
           PKG_JSON=./packages/snfoundry/package.json
           PARSE_DEPLOY=./packages/snfoundry/scripts-ts/helpers/parse-deployments.ts
+          VERIFY_CONTRACTS=./packages/snfoundry/scripts-ts/verify-contracts.ts
 
           if [ ! -f "$PKG_JSON" ]; then
             CONFLICT=true
@@ -134,10 +135,21 @@ jobs:
           fi
 
           if [ "$CONFLICT" != "true" ]; then
+            if [ ! -f "$VERIFY_CONTRACTS" ]; then
+              CONFLICT=true
+              REASON="$VERIFY_CONTRACTS not found after rsync — upstream layout changed."
+            elif ! grep -q 'nextjs/contracts' "$VERIFY_CONTRACTS"; then
+              CONFLICT=true
+              REASON="grep 'nextjs/contracts' not found in $VERIFY_CONTRACTS — upstream may have moved the contracts target dir."
+            fi
+          fi
+
+          if [ "$CONFLICT" != "true" ]; then
             sed -i 's|@ss-2/snfoundry|@ss-rn/snfoundry|g' "$PKG_JSON"
             sed -i 's|nextjs/contracts|rn/contracts|g' "$PARSE_DEPLOY"
+            sed -i 's|nextjs/contracts|rn/contracts|g' "$VERIFY_CONTRACTS"
             # Post-rewrite verification: ensure the old strings are gone.
-            if grep -q '@ss-2/snfoundry' "$PKG_JSON" || grep -q 'nextjs/contracts' "$PARSE_DEPLOY"; then
+            if grep -q '@ss-2/snfoundry' "$PKG_JSON" || grep -q 'nextjs/contracts' "$PARSE_DEPLOY" || grep -q 'nextjs/contracts' "$VERIFY_CONTRACTS"; then
               CONFLICT=true
               REASON="sed rewrites left residual @ss-2/snfoundry or nextjs/contracts references — manual review required."
             fi


### PR DESCRIPTION
## Problem

`sync-rn-repo.yaml` applies deterministic sed rewrites for rn-fork structural deltas. It rewrites the `nextjs/contracts` → `rn/contracts` path delta in `parse-deployments.ts`, but `scripts-ts/verify-contracts.ts` has the **same** delta (`import deployedContracts from "../../nextjs/contracts/deployedContracts"`) and was **not** rewritten. As a result it syncs to `scaffold-stark-rn` with a broken `nextjs/contracts` import path.

## Fix

Surgical addition mirroring the exact existing proven `PARSE_DEPLOY` pattern:

- `VERIFY_CONTRACTS` variable alongside `PARSE_DEPLOY`
- File-exists + `grep 'nextjs/contracts'` sanity gate (so an upstream move surfaces as a conflict PR, not a silent no-op)
- `sed -i 's|nextjs/contracts|rn/contracts|g'` rewrite
- Added to the post-rewrite residual `grep` check

No changes to `parse-deployments.ts` handling or any unrelated workflow logic. CONFLICT/REASON gating style kept identical.

## Verification

- YAML validated with `python3 yaml.safe_load` — OK
- Extracted run-script block validated with `bash -n` — OK
- Diff: 13 insertions, 1 deletion (the deletion is the extended residual-check line)