### PR TITLE
fix: add explicit GITHUB_TOKEN permissions to all workflows

### DIFF
--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -8,6 +8,9 @@ on:
       - "packages/nextjs/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   version-bump-nextjs:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ on:
       - "packages/nextjs/**"
       - "packages/snfoundry/**"
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release-create-stark.yaml
+++ b/.github/workflows/release-create-stark.yaml
@@ -5,6 +5,9 @@ on:
     types: [closed]
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check_commit:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/sync-basecamp-repo.yaml
+++ b/.github/workflows/sync-basecamp-repo.yaml
@@ -21,6 +21,9 @@ on:
         default: 'main'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   check_commit:
     if: github.event_name != 'pull_request' || github.event.pull_request.merged == true

--- a/.github/workflows/sync-rn-repo.yaml
+++ b/.github/workflows/sync-rn-repo.yaml
@@ -21,6 +21,9 @@ on:
         default: 'main'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   check_commit:
     if: github.event_name != 'pull_request' || github.event.pull_request.merged == true

--- a/.github/workflows/sync-speedrun-repo.yaml
+++ b/.github/workflows/sync-speedrun-repo.yaml
@@ -21,6 +21,9 @@ on:
         default: 'main'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   check_commit:
     if: github.event_name != 'pull_request' || github.event.pull_request.merged == true


### PR DESCRIPTION
## What

Adds `permissions: contents: read` to the 6 workflow files missing an explicit permissions block. (`sync-bulletproof-contracts.yaml` already had one at the job level.)

## Why

All write operations use `ORG_GITHUB_TOKEN` (PAT), so the default `GITHUB_TOKEN` only needs `contents: read`. This follows GitHub's security hardening guidance and would resolve CodeQL warnings if scanning were enabled.

**Affected files:** `main.yml`, `demo.yaml`, `release-create-stark.yaml`, `sync-basecamp-repo.yaml`, `sync-rn-repo.yaml`, `sync-speedrun-repo.yaml`