### PR TITLE
chore(release): 3.0.2 [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ss-2",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "Q3 Labs",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Manual version bump to 3.0.2.

The auto-release workflow (`release-create-stark.yaml`) created the version bump commit locally but couldn't push it because the npm publish step failed (`NPM_TOKEN` has no write access to `create-stark` package).