### PR TITLE
chore: add portable drift-check workflow, harden .claude leakage paths

### DIFF
--- a/.claude/skills/stark-sync-phase2/SKILL.md
+++ b/.claude/skills/stark-sync-phase2/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: stark-sync-phase2
+description: Phase 2 — propagate an already-merged scaffold-stark-2 update out to its sibling forks and the create-stark npm template. Verifies whether each target's sync automation actually worked, and repairs broken automation rather than hand-patching the target. Use only AFTER Phase 1 changes are merged; run stark-update-phase1 first.
+---
+
+# Phase 2 — Propagate to siblings
+
+Answer: **did each sibling actually receive the Phase 1 changes, and if not, why?**
+
+## Precondition — do not start without this
+
+Phase 2 propagates *already-merged* work. Verify Phase 1 actually landed before touching anything:
+
+```sh
+git log --oneline origin/main -5
+git log --oneline origin/main..origin/develop | wc -l    # unreleased work sitting on develop
+```
+
+If the Phase 1 changes are still on `develop` or still in an open PR, **stop**. Syncing now propagates a half-state, and re-syncing later produces conflicts on top of it.
+
+## Governing rule — repair, do not bypass
+
+When a target is out of date **and** has automation, the automation is the defect. Fix the workflow so it works, then let it run.
+
+Do **not** hand-patch the target repo. A manual edit gets overwritten by the next successful sync, hides the broken automation, and has to be redone every release. The one exception is a target with **no** automation at all — see the routing table.
+
+---
+
+## Targets
+
+| Target | Kind | Automation | Trigger |
+|---|---|---|---|
+| `Scaffold-Stark/speedrunstark` | fork | `sync-speedrun-repo.yaml` | push(develop) + PR-closed + **dispatch** |
+| `Scaffold-Stark/basecamp` | fork | `sync-basecamp-repo.yaml` | push(develop) + PR-closed + **dispatch** |
+| `Scaffold-Stark/scaffold-stark-rn` | fork (sed-rewritten) | `sync-rn-repo.yaml` | push(develop) + PR-closed + **dispatch** |
+| `v3-bulletproof-contracts` | **branch inside this repo** | `sync-bulletproof-contracts.yaml` | push(develop) **only** |
+| `Scaffold-Stark/create-stark` | **npm package template** | `release-create-stark.yaml` | PR-closed **only** |
+
+Two structural constraints that shape everything below:
+
+- **`sync-bulletproof-contracts` and `release-create-stark` have no `workflow_dispatch`.** They cannot be triggered manually. If they need to run, either a qualifying event must occur or the workflow needs a `workflow_dispatch` block added first.
+- **Releases are pushed to `main` as `chore(release): X` with `[skip ci]`.** Sync workflows fire on `push: branches:[develop]` or `pull_request: closed`. A release push therefore fires **nothing**. Do not assume a release propagated.
+
+---
+
+## Step 1 — Did the automation run, and did it *work*?
+
+These are different questions. Run all three checks per target; a target passes only if all three agree.
+
+```sh
+# (a) did it run at all?
+gh run list --workflow <file> --limit 10 --json conclusion,createdAt,headBranch
+
+# (b) does the trigger still resolve? (a deleted branch silently kills a workflow)
+git ls-remote --heads origin develop
+
+# (c) DID IT PRODUCE ANYTHING? — the check that actually matters
+gh api repos/Scaffold-Stark/<target>/commits --jq '.[0:10] | .[] | "\(.commit.author.date) \(.author.login // "?") \(.commit.message | split("\n")[0])"'
+```
+
+**Green runs prove nothing.** This repo's sync workflows have reported `success` while merging nothing, because a `|| echo` swallowed the merge's exit code and the subsequent push was a no-op. Confirmed in run `26048950811`: 11 conflicts, `Automatic merge failed`, then `No changes to merge`, then `Everything up-to-date`, conclusion `success`.
+
+**Check commit *provenance*, not recency.** A target can carry recent commits produced by a side-effect step while the step you care about has never once succeeded. On the bulletproof branch, every `chore: update Docker versions [CI]` commit landed while **zero** `origin/develop` merges ever did — the branch looked maintained and was not.
+
+```sh
+# for the bulletproof branch specifically:
+git log origin/v3-bulletproof-contracts --merges --oneline -15   # any 'develop' merges? or only 'main'?
+git log origin/develop ^origin/v3-bulletproof-contracts --oneline | wc -l   # how far behind
+```
+
+For fork targets, compare the actual files rather than trusting commit counts — a fork can be N commits behind while the only content difference is a version string:
+
+```sh
+gh api repos/Scaffold-Stark/<target>/contents/.tool-versions --jq '.content' | base64 -d
+gh api repos/Scaffold-Stark/<target>/contents/packages/snfoundry/contracts/Scarb.toml --jq '.content' | base64 -d
+```
+
+## Step 2 — Classify each target
+
+| Finding | Action |
+|---|---|
+| Automation ran, target has the changes | **Clean.** Say so and move on. |
+| Automation ran green but target unchanged | **Broken automation.** Read the run log; look for a swallowed exit code and an unconditional push. Fix the workflow. |
+| Automation never ran | **Trigger problem.** Is the branch it fires on still present? Did the event actually occur? A release push with `[skip ci]` fires nothing. |
+| Automation ran and failed loudly | Read the failure. Usually a real conflict needing resolution — that is a legitimate PR, not a workflow bug. |
+| No automation for this target | Only case where a manual sync PR is correct. |
+
+## Step 3 — Repairing broken automation
+
+Known defect patterns in this repo's sync workflows, in the order worth checking:
+
+**Swallowed exit code.** `git merge ... || echo "..."` followed by an unconditional push reports success while doing nothing. The fix is `|| { git merge --abort; exit 1; }`. While there, check whether the fallback message *asserts* something false — `|| echo "No changes to merge"` printed after a failed merge tells the next reader the opposite of the truth and stops them looking.
+
+**Persist path gated on the wrong condition.** For every artefact a job produces, ask whether a path exists for it to reach the remote, and whether that path is gated on the same thing that produced it. A merge guarded by "did file X change" can only be pushed by coincidence.
+
+**No failure notification.** `sync-bulletproof-contracts.yaml` is the only sync workflow with no Slack step, which is why its failure went unseen. Add one when repairing it.
+
+**Path filter vs rsync scope disagreeing.** The push filter lists six paths while the rsync copies the whole tree. Either broaden the filter or narrow the rsync — as written, a change to an unlisted path never triggers a sync that would have copied it.
+
+After repairing, trigger and re-verify with Step 1 — a repair claimed but not observed is not a repair.
+
+## Step 4 — create-stark (npm template)
+
+Highest blast radius: its rsync feeds `destination_repo/templates/base`, which is then `npm publish`ed and scaffolded onto every user's disk by `npx create-stark`.
+
+```sh
+npm view create-stark version                       # published
+git log --oneline -1 origin/main                    # what this repo is at
+gh run list --workflow release-create-stark.yaml --limit 5
+```
+
+**Generator templates are a separate sync surface.** Carry-over from 2026-05-18: an org-wide toolchain sync reached parity in `package.json` but missed the nested Cairo manifest inside the template — `template/snfoundry/contracts/Scarb.toml` never received the OZ 3.0 dependency. When verifying template parity, check the **nested** `Scarb.toml` and `.tool-versions` inside `templates/base`, not only the top-level ones.
+
+Verify the published artefact, not just the repo:
+
+```sh
+cd $(mktemp -d) && npm pack create-stark@latest && tar -xzf create-stark-*.tgz
+grep -r "scarb\|snforge_std" package/templates/base/.tool-versions \
+  package/templates/base/packages/snfoundry/contracts/Scarb.toml 2>/dev/null
+```
+
+A template can scaffold cleanly and still ship a broken import — the published `scaffold-stark-rn` v1.0.6 carried a dangling `verify-contracts.ts` import for exactly this reason. If you can, scaffold and typecheck rather than only reading files.
+
+---
+
+## Known constraints
+
+- **`scaffold-stark-rn` may be under a captain deferral.** Check the current handoff before proposing work on it; if deferred, report its state and do not rank it actionable unless materially worse.
+- **`v3-bulletproof-contracts` is a branch, not a repo.** It cannot be checked with `gh api repos/...`; use `git log origin/v3-bulletproof-contracts`.
+- **A toolchain bump propagates to every target.** `.tool-versions` is copied wholesale by the fork syncs and greped by `sync-bulletproof-contracts.yaml` to stamp a Docker image tag. Verify that tag exists before syncing a devnet bump, or the workflow emits a broken image reference.
+
+## Before claiming a target is synced
+
+Report actual output, never assertions:
+
+```sh
+gh run list --workflow <file> --limit 3         # the triggered run and its conclusion
+gh api repos/Scaffold-Stark/<target>/commits --jq '.[0].commit.message'   # what landed
+```
+
+State which targets you verified, which you could not, and why. "I did not find a problem" and "there is no problem" are different claims — only one is checkable.
+
+## Output format
+
+1. **One sentence:** are all targets in sync?
+2. **Per target:** clean / broken-automation / trigger-problem / needs-manual, with the evidence.
+3. **Repairs needed**, tagged CODE (crew) or OPS (captain), with branch names.
+4. **Verified clean** — explicitly, so silence is not read as coverage.
+
+## Not in scope
+
+Dependency selection and changelog review — that is `stark-update-phase1`. This skill only propagates what Phase 1 already decided and merged.

--- a/.claude/skills/stark-sync-phase2/SKILL.md
+++ b/.claude/skills/stark-sync-phase2/SKILL.md
@@ -125,7 +125,7 @@ A template can scaffold cleanly and still ship a broken import — the published
 
 ## Known constraints
 
-- **`scaffold-stark-rn` may be under a captain deferral.** Check the current handoff before proposing work on it; if deferred, report its state and do not rank it actionable unless materially worse.
+- **`scaffold-stark-rn` may be intentionally deferred.** Check whether it is intentionally deferred before proposing work on it; if so, report its state and do not rank it actionable unless materially worse.
 - **`v3-bulletproof-contracts` is a branch, not a repo.** It cannot be checked with `gh api repos/...`; use `git log origin/v3-bulletproof-contracts`.
 - **A toolchain bump propagates to every target.** `.tool-versions` is copied wholesale by the fork syncs and greped by `sync-bulletproof-contracts.yaml` to stamp a Docker image tag. Verify that tag exists before syncing a devnet bump, or the workflow emits a broken image reference.
 
@@ -144,7 +144,7 @@ State which targets you verified, which you could not, and why. "I did not find 
 
 1. **One sentence:** are all targets in sync?
 2. **Per target:** clean / broken-automation / trigger-problem / needs-manual, with the evidence.
-3. **Repairs needed**, tagged CODE (crew) or OPS (captain), with branch names.
+3. **Repairs needed**, tagged CODE (needs a code change) or OPS (a repo action, no code change), with branch names.
 4. **Verified clean** — explicitly, so silence is not read as coverage.
 
 ## Not in scope

--- a/.claude/skills/stark-update-phase1/SKILL.md
+++ b/.claude/skills/stark-update-phase1/SKILL.md
@@ -96,20 +96,26 @@ for p in chains explorers providers react; do npm view "@starknet-start/$p" vers
 
 `starknet` is a direct dependency of **both** `packages/nextjs` (hooks, components) **and** `packages/snfoundry` (deploy scripts). A major bump touches both — never treat it as frontend-only.
 
-> Registry quirk: `npm view starknet version` returns the `latest` dist-tag, which has lagged behind published versions before (10.0.2 as `latest` while 10.0.3–10.4.0 existed and 10.5.0 sat on `next`). Check `npm view starknet versions --json | tail` if the number looks suspiciously round.
+> **Registry quirk and caret trap**: `npm view starknet version` returns the `latest` dist-tag, which has lagged behind published versions before. Check `npm view starknet versions --json | tail` if the number looks suspiciously round.
+> **CRITICAL:** Verified 2026-07-21: dist-tags were `latest=10.0.2`, `next=10.5.0` — `10.5.0` carried no prerelease suffix, so `^10.0.2` resolved to `10.5.0`, pulling the unstable `next` channel. Always verify `npm view starknet dist-tags --json` and check what the range actually resolves to. A version on the `next` channel without a prerelease suffix will bypass the caret and resolve automatically. Any v10 adoption must pin the exact version, never a caret, because the range propagates to every fork via sync and breaks them.
 
 ## Step 4 — Next.js frontend and security
 
 ```sh
-yarn outdated || npm outdated --workspaces      # if this fails, fall back to npm view per direct dep
+# Yarn Berry lacks an 'outdated' command, so fallback to a direct package loop:
+for p in next react eslint-config-next vitest typescript daisyui zustand next-themes usehooks-ts qrcode.react; do
+  cur=$(grep -m1 "\"$p\":" packages/nextjs/package.json | sed 's/.*: *"//; s/".*//')
+  printf '%-22s current=%-12s latest=%s\n' "$p" "$cur" "$(npm view "$p" version 2>/dev/null)"
+done
+
 yarn npm audit || npm audit --workspaces
-gh api --paginate repos/Scaffold-Stark/scaffold-stark-2/dependabot/alerts \
-  --jq '[.[]|select(.state=="open")|.security_advisory.severity]|group_by(.)|map({(.[0]):length})|add'
+gh api --paginate --slurp "repos/Scaffold-Stark/scaffold-stark-2/dependabot/alerts?per_page=100&state=open" > /tmp/a.json
+jq 'add | {total: length, by_sev: (group_by(.security_advisory.severity)|map({(.[0].security_advisory.severity):length})|add)}' /tmp/a.json
 ```
 
 The org is **`Scaffold-Stark`**, not `Quantum3-Labs`. A `gh api` call against the wrong org fails in a way that looks like "no alerts".
 
-**`--paginate` is mandatory.** Without it `gh api` returns only the first page (30 items), so the count silently undercounts — it answers "how many on page one", not "how many are open". Verified 2026-07-20: 25 without, 29 with.
+**Do not pipe `--paginate` directly to `--jq` inside `gh api`.** That combination applies the `jq` filter to each page separately, emitting one JSON object per page instead of an aggregate. A careless read takes the final page's line and reports it as the total (e.g., 29 items instead of 107). Instead, use `--slurp` to output a single array of pages to a file, then run `jq` externally.
 
 Focus on **direct** dependencies: `next`, `react`, `eslint-config-next`, `vitest`, `typescript`, and the UI set (`daisyui`, `zustand`, `@radix-ui/themes`, `usehooks-ts`, `qrcode.react`, `next-themes`). Fold routine patch drift in dev tooling into **one** informational line — not twenty findings.
 
@@ -132,7 +138,7 @@ Review this list each release; stale entries here cause missed regressions.
 - **TanStack** May-2026 compromise: not exposed. Resolved versions predate the window; `yarn.lock` pins per-artifact sha512.
 - **`next-pwa` is abandoned** (last publish 2022) and pulls a second `next@13.5.11` tree, which is the source of most remaining alerts — all build-time. Migration target is `@serwist/next`. Known, deferred.
 - The Dependabot backlog reports every alert as `scope=runtime` because they trace through `yarn.lock`. That labelling is useless here; judge reachability yourself.
-- **Alert count as of 2026-07-20: 29 open — 10 high, 12 medium, 7 low, zero critical.** Treat this as a baseline to diff against, not a fact to repeat. A jump above ~35, or any critical appearing, is the signal worth acting on. (Earlier figures of 78 and 107 in the May/July reports were unpaginated or double-counted — do not trust them as history.)
+- **Alert count as of 2026-07-21: 107 open — 1 critical, 51 high, 39 medium, 16 low.** The single critical is GHSA-5xrq-8626-4rwp (vitest UI server arbitrary file read/execute, vulnerable <3.2.6). Treat this baseline as a diffing target, not a fact to repeat. A jump above ~115, or any *new* critical appearing, is the signal worth acting on. (Earlier low counts like 29 were caused by the per-page `jq` bug described in Step 4 — 107 is the correct historical baseline).
 
 ---
 

--- a/.claude/skills/stark-update-phase1/SKILL.md
+++ b/.claude/skills/stark-update-phase1/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: stark-update-phase1
+description: Phase 1 — check and update dependencies for scaffold-stark-2 itself (Starknet toolchain, Cairo/OpenZeppelin, starknet.js, Next.js frontend, security advisories). Use when asked "does anything need updating?", before planning a release, or when returning to the project after time away. Phase 1 covers THIS repo only; sibling forks are Phase 2 and must not be touched here.
+---
+
+# Phase 1 — Update scaffold-stark-2
+
+Answer one question: **which dependencies in this repo need updating, and which should deliberately stay put?**
+
+Scope is **this repo only**. Siblings (`speedrunstark`, `basecamp`, `scaffold-stark-rn`, branch `v3-bulletproof-contracts`) are Phase 2. Do not check or modify them here — they receive changes from this repo via sync workflows, so fixing them before this repo is done gets overwritten.
+
+## Prime directives
+
+**Never state a version from memory.** Your training data is stale relative to this project. Every "latest" must come from a live lookup in this session. If a lookup fails, write `unverified` — an unverified claim is worse than a gap.
+
+**Do not recommend an upgrade just because a newer version exists.** Recommend it only when the delta fixes a real problem, closes a *reachable* security gap, or unblocks something. For each upgrade you do recommend, say what would break.
+
+**Read the KNOWN block below before reporting anything.** It lists conditions already investigated and settled. Re-reporting them is noise.
+
+**If something is fine, say so plainly.** Do not invent busywork to look thorough.
+
+**A version gap is not a finding. The changelog is the finding.** Reporting `2.18.0 → 2.19.3`
+tells the reader nothing they can decide on. For **every** upgrade you surface, you must read
+what actually changed and report it. This is not optional and it is the main output of this
+skill — a report of bare version numbers has failed regardless of how accurate the numbers are.
+
+For each gap, read the release notes across **every intervening version**, not just the newest:
+
+```sh
+gh release view <tag> --repo <owner>/<repo>                      # one release
+gh release list --repo <owner>/<repo> --limit 20 --exclude-pre-releases
+gh api repos/<owner>/<repo>/releases --jq '.[]|select(.tag_name>="vX")|{tag:.tag_name,body:.body}'
+```
+
+For npm packages without GitHub releases, fetch `CHANGELOG.md` from the repo, or the package's
+`repository` URL from `npm view <pkg> repository.url`.
+
+Report per upgrade, in this order:
+1. **Breaking changes** — what would stop compiling or running. If none, say "no breaking changes".
+2. **Bug fixes that matter to this project** — especially anything touching contract compilation,
+   declare/deploy flow, RPC spec, account/provider APIs, or test execution.
+3. **New capability** worth adopting, if any.
+4. **Migration cost** — concretely, which files here would need editing.
+
+If the release notes are empty or uninformative, say so and fall back to comparing tags
+(`gh api repos/<owner>/<repo>/compare/<old>...<new> --jq '.commits[].commit.message'`). Never
+substitute a guess about what a version "probably" contains — mark it `unverified` instead.
+
+---
+
+## Step 1 — Starknet toolchain
+
+Source of truth: **`.tool-versions`** at repo root. CI reads this file directly via `grep`, so it is authoritative — not any version mentioned in a workflow file.
+
+```sh
+cat .tool-versions
+gh release list --repo software-mansion/scarb --limit 5 --exclude-pre-releases
+gh release list --repo foundry-rs/starknet-foundry --limit 5 --exclude-pre-releases
+gh release list --repo 0xSpaceShard/starknet-devnet --limit 5 --exclude-pre-releases
+```
+
+> **Do not read the first line as "latest".** `gh release list` sorts by date, so pre-releases
+> appear above the stable release — scarb has shown `v2.20.0-rc.1` on top while `v2.19.3` carried
+> the `Latest` tag. Either pass `--exclude-pre-releases` as above, or read the row explicitly
+> marked `Latest`. Recommending an `-rc` build into `.tool-versions` would propagate a pre-release
+> to every fork.
+
+Rules specific to this stack:
+
+- **`snforge_std` (Scarb.toml) and `starknet-foundry` (.tool-versions) must move in lockstep.** A version mismatch makes snforge refuse to run. Never recommend moving one alone — they go in the same commit.
+- **`starknet-devnet` is 0.x, so treat a minor bump as breaking.** 0.9.0 pulled in Starknet v0.14.3 RPC spec changes.
+- **Before recommending a devnet bump, verify its Docker image tag actually exists** (`shardlabs/starknet-devnet-rs:<version>`). `sync-bulletproof-contracts.yaml` greps `.tool-versions` to stamp that tag — a nonexistent tag breaks the workflow.
+- A toolchain bump propagates to all sibling forks. Flag it as needing coordinated rollout, and **defer the actual sibling work to Phase 2**.
+
+## Step 2 — Cairo / OpenZeppelin
+
+Source of truth: **`packages/snfoundry/contracts/Scarb.toml`**, cross-checked against `Scarb.lock` for what actually resolves.
+
+```sh
+cat packages/snfoundry/contracts/Scarb.toml
+gh release list --repo OpenZeppelin/cairo-contracts --limit 5
+```
+
+Check `openzeppelin_access`, `openzeppelin_token`, `openzeppelin_interfaces`, `openzeppelin_utils`, `snforge_std`.
+
+## Step 3 — starknet.js and @starknet-start
+
+These are the packages most likely to actually need work, and they span **two** workspaces.
+
+```sh
+grep -n '"starknet"' packages/*/package.json          # used in BOTH nextjs and snfoundry
+grep -n '@starknet-start' packages/nextjs/package.json
+npm view starknet version
+for p in chains explorers providers react; do npm view "@starknet-start/$p" version; done
+```
+
+`starknet` is a direct dependency of **both** `packages/nextjs` (hooks, components) **and** `packages/snfoundry` (deploy scripts). A major bump touches both — never treat it as frontend-only.
+
+> Registry quirk: `npm view starknet version` returns the `latest` dist-tag, which has lagged behind published versions before (10.0.2 as `latest` while 10.0.3–10.4.0 existed and 10.5.0 sat on `next`). Check `npm view starknet versions --json | tail` if the number looks suspiciously round.
+
+## Step 4 — Next.js frontend and security
+
+```sh
+yarn outdated || npm outdated --workspaces      # if this fails, fall back to npm view per direct dep
+yarn npm audit || npm audit --workspaces
+gh api --paginate repos/Scaffold-Stark/scaffold-stark-2/dependabot/alerts \
+  --jq '[.[]|select(.state=="open")|.security_advisory.severity]|group_by(.)|map({(.[0]):length})|add'
+```
+
+The org is **`Scaffold-Stark`**, not `Quantum3-Labs`. A `gh api` call against the wrong org fails in a way that looks like "no alerts".
+
+**`--paginate` is mandatory.** Without it `gh api` returns only the first page (30 items), so the count silently undercounts — it answers "how many on page one", not "how many are open". Verified 2026-07-20: 25 without, 29 with.
+
+Focus on **direct** dependencies: `next`, `react`, `eslint-config-next`, `vitest`, `typescript`, and the UI set (`daisyui`, `zustand`, `@radix-ui/themes`, `usehooks-ts`, `qrcode.react`, `next-themes`). Fold routine patch drift in dev tooling into **one** informational line — not twenty findings.
+
+**For every advisory, determine reachability before assigning severity.** This repo carries a large alert backlog that is almost entirely build-time. The question is never "is there an advisory" but "does it reach the deployed dapp bundle". A dev-only or build-time advisory is `low`, whatever its CVSS.
+
+---
+
+## KNOWN — settled conditions, do not re-report
+
+Review this list each release; stale entries here cause missed regressions.
+
+**Intentional, not drift:**
+- `starknet = ">=2.18.0"` in Scarb.toml is an **open floor by design**. It already accepts 2.19.x. The real constraint is the scarb pin in `.tool-versions`. An open floor is not lag.
+- **TypeScript stays on `^5`.** npm `latest` points at the Go-native TS7 compiler; `ts-node` and `typescript-eslint@^7` are not ready.
+- **ESLint stays on `^8`** until `typescript-eslint` is bumped — `@^7` caps at eslint 8, and moving requires a flat-config migration.
+- **Next 15 → 16 and starknet.js v9 → v10 are deliberate deferrals**, each needing its own migration pass. Raise them only if a security fix lands that is unavailable on the current major.
+
+**Already investigated (verified 2026-07-20) — report only if status changed:**
+- `overrides` blocks in root/nextjs/snfoundry `package.json` are **inert**: this is Yarn Berry (`yarn@3.2.3`), which reads `resolutions`. Known.
+- **TanStack** May-2026 compromise: not exposed. Resolved versions predate the window; `yarn.lock` pins per-artifact sha512.
+- **`next-pwa` is abandoned** (last publish 2022) and pulls a second `next@13.5.11` tree, which is the source of most remaining alerts — all build-time. Migration target is `@serwist/next`. Known, deferred.
+- The Dependabot backlog reports every alert as `scope=runtime` because they trace through `yarn.lock`. That labelling is useless here; judge reachability yourself.
+- **Alert count as of 2026-07-20: 29 open — 10 high, 12 medium, 7 low, zero critical.** Treat this as a baseline to diff against, not a fact to repeat. A jump above ~35, or any critical appearing, is the signal worth acting on. (Earlier figures of 78 and 107 in the May/July reports were unpaginated or double-counted — do not trust them as history.)
+
+---
+
+## Grouping the work
+
+Do not produce a flat list. Group into PRs by risk, because these have very different review needs:
+
+**Batch 1 — safe, one PR.** Same-major bumps and version alignments. Anything where the existing semver range already permits the new version is lockfile-only and near-zero risk.
+
+**Batch 2 — toolchain, breaking, coordinated.** `.tool-versions` + `Scarb.toml` + `Scarb.lock` in a single commit. Must not be split.
+
+> **Carry-over from 2026-05-18:** a previous org-wide toolchain sync reached parity in `package.json` but **missed the nested Cairo manifest inside the generator template** — `create-stark-rn/template/snfoundry/contracts/Scarb.toml` never got the OZ 3.0 dep. Template copies are a **separate sync surface**. When bumping the toolchain, explicitly check the `Scarb.toml` inside the create-stark template, not just the ones under `packages/`.
+
+**Batch 3 — migrations, one PR each.** starknet.js v10, UI major bumps, `next-pwa` → `@serwist/next`. Never bundle these.
+
+---
+
+## Before claiming anything is done
+
+Run these and report **actual output**. Do not assert.
+
+```sh
+yarn install --immutable    # lockfile actually resolves
+yarn next:check-types       # types still compile
+yarn test:nextjs            # frontend tests
+cd packages/snfoundry/contracts && scarb build && snforge test
+```
+
+If `scarb build` fails with a cache error, `scarb clean` first — a corrupted package cache has produced false build failures here before.
+
+State plainly what passed, what failed, and what you did not run. A skipped check reported as silence is the most common way a bad update ships.
+
+## Output format
+
+1. **One sentence:** does anything actually need updating right now?
+2. **Findings** ranked `blocker > needs-update > nice-to-have`, each tagged **CODE** (needs a crew) or **OPS** (captain does directly).
+3. **Batches** as above, with suggested branch names.
+4. **Checked and clean** — say explicitly what was verified as current, so silence is not mistaken for coverage.
+5. **Deferred, with reasons** — so the next run does not re-litigate them.
+
+## Not in scope
+
+Sibling repos, sync-workflow health, CI configuration, open PR triage. Those belong to Phase 2 or to the `stark-drift-check` workflow. Keep this skill about dependencies.

--- a/.claude/skills/stark-update-phase1/SKILL.md
+++ b/.claude/skills/stark-update-phase1/SKILL.md
@@ -174,7 +174,7 @@ State plainly what passed, what failed, and what you did not run. A skipped chec
 ## Output format
 
 1. **One sentence:** does anything actually need updating right now?
-2. **Findings** ranked `blocker > needs-update > nice-to-have`, each tagged **CODE** (needs a crew) or **OPS** (captain does directly).
+2. **Findings** ranked `blocker > needs-update > nice-to-have`, each tagged **CODE** (needs a code change) or **OPS** (a repo action, no code change).
 3. **Batches** as above, with suggested branch names.
 4. **Checked and clean** — say explicitly what was verified as current, so silence is not mistaken for coverage.
 5. **Deferred, with reasons** — so the next run does not re-litigate them.

--- a/.claude/workflows/stark-drift-check.mjs
+++ b/.claude/workflows/stark-drift-check.mjs
@@ -1,0 +1,337 @@
+export const meta = {
+  name: 'stark-drift-check',
+  description: 'Audit the scaffold-stark ecosystem for drift: repo/PR state, sync-workflow health, toolchain lag, and an optional devnet deploy smoke test',
+  whenToUse: 'Run at the start of a session after time away, to answer "does anything need updating?" across scaffold-stark-2 and its sync targets',
+  phases: [
+    { title: 'Audit', detail: 'parallel: primary repo, sync health, siblings, upstream deps' },
+    { title: 'Smoke', detail: 'optional devnet scaffold+deploy end-to-end check' },
+    { title: 'Synthesize', detail: 'merge into one ranked, CODE-vs-OPS actionable list' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+// No hardcoded repo path or org — every agent below derives these itself so this
+// workflow runs unmodified from any clone or fork:
+//   REPO_ROOT = `git rev-parse --show-toplevel`
+//   ORG       = the owner segment of `git remote get-url origin`
+const REPO_CONTEXT = `
+Derive these before anything else and use them for every command below:
+  REPO_ROOT = $(git rev-parse --show-toplevel)
+  ORG       = the owner segment of \`git remote get-url origin\`
+              (e.g. git@github.com:OWNER/repo.git or https://github.com/OWNER/repo)
+`
+
+const SIBLINGS = [
+  {
+    key: 'speedrunstark',
+    repo: 'speedrunstark',
+    syncedBy: 'sync-speedrun-repo.yaml',
+    role: 'speedrun challenge fork; receives full-tree rsync from primary',
+  },
+  {
+    key: 'basecamp',
+    repo: 'basecamp',
+    syncedBy: 'sync-basecamp-repo.yaml',
+    role: 'basecamp curriculum fork; receives full-tree rsync from primary',
+  },
+  {
+    key: 'scaffold-stark-rn',
+    repo: 'scaffold-stark-rn',
+    syncedBy: 'sync-rn-repo.yaml',
+    role: 'React Native fork; receives sed-rewritten sync (nextjs -> rn paths)',
+    deferred: true, // audit and report state, but do not recommend action unless materially worsened
+  },
+  {
+    key: 'v3-bulletproof-contracts',
+    repo: 'scaffold-stark-2 (branch: v3-bulletproof-contracts)',
+    syncedBy: 'sync-bulletproof-contracts.yaml',
+    role: 'INTRA-repo long-lived branch, not a separate repo; develop is merged into it',
+  },
+]
+
+const SIBLINGS_TEXT = SIBLINGS.map((s) => {
+  const label = s.key === 'v3-bulletproof-contracts' ? s.repo : `ORG/${s.repo}`
+  const deferredNote = s.deferred
+    ? '\n      *** DEFERRED — audit and report state, but do NOT recommend action unless materially worsened ***'
+    : ''
+  return `  - ${s.key} | repo: ${label} | synced by: ${s.syncedBy}\n      role: ${s.role}${deferredNote}`
+}).join('\n')
+
+// Toolchain pins. Update this list when pins move.
+const PINS = `
+  .tool-versions (AUTHORITATIVE — CI greps this file directly):
+    scarb 2.18.0 | starknet-foundry 0.60.0 | starknet-devnet 0.8.1
+  packages/snfoundry/contracts/Scarb.toml:
+    starknet ">=2.18.0" | openzeppelin_access ">=3.0.0" | openzeppelin_token ">=3.0.0"
+    openzeppelin_interfaces ">=2.0.0" | openzeppelin_utils ">=2.0.0" | snforge_std "0.60.0" (exact)
+  packages/nextjs: next 15.5.18 | react 19.0.3 | starknet ^9.4.2 | vitest 3.2.4
+`
+
+// ---------------------------------------------------------------------------
+// Known conditions. Agents MUST NOT re-report these as new problems.
+// This block is what keeps the report free of busywork.
+//
+// REVIEW THIS BLOCK EACH RELEASE. Pins and "known" statuses below go stale
+// fast — an unreviewed entry here silently swallows real drift instead of
+// flagging it.
+// ---------------------------------------------------------------------------
+
+const KNOWN = `
+KNOWN AND INTENTIONAL — do not report these as findings:
+- \`starknet = ">=2.18.0"\` in Scarb.toml is an OPEN FLOOR, deliberately. It already accepts
+  2.19.x. The real toolchain constraint is the scarb pin in .tool-versions. An open floor is
+  not drift.
+- TypeScript stays on ^5. npm "latest" now points at the Go-native TS7 compiler; ts-node and
+  typescript-eslint ^7 are not ready. Staying is correct, not lag.
+- Staying on Next 15 (not 16) and starknet.js v9 (not v10) are deliberate deferrals, each
+  needing its own migration pass coordinated across forks. Mention only if a SECURITY fix
+  lands that is unavailable on the current major.
+
+KNOWN AND ALREADY TRACKED — report only if the STATUS has changed:
+- \`overrides\` blocks in root/nextjs/snfoundry package.json are inert: this is Yarn Berry
+  (yarn@3.2.3), which reads \`resolutions\`, not \`overrides\`. Already logged.
+- \`daisyui: "latest"\` in packages/nextjs is an unpinned specifier resolving a different major
+  than root. Known, tracked.
+`
+
+const GUARDRAILS = `
+READ-ONLY. Do not edit, commit, push, or open anything. Only the Smoke phase executes, and
+even it must not modify the primary repo (REPO_ROOT) or any sibling repo it audits.
+
+Report what you actually OBSERVE from commands you ran. Never state a version from memory —
+your training data is stale relative to this project. If you cannot verify something from a
+live source, say "unverified" rather than guessing. An unverified claim is worse than a gap.
+
+Do NOT recommend an upgrade just because a newer version exists. Recommend it only when the
+delta fixes a real problem, closes a reachable security gap, or unblocks something. For each
+upgrade you DO recommend, say what would break.
+
+If an area is fine, say so plainly. Do not invent busywork to look thorough.
+`
+
+// ---------------------------------------------------------------------------
+// Schema — severity is decision-shaped, and every finding is CODE or OPS.
+// ---------------------------------------------------------------------------
+
+const FINDINGS = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['summary', 'findings'],
+  properties: {
+    summary: { type: 'string', description: 'One sentence: is this area clean or does it need attention?' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['title', 'severity', 'kind', 'detail', 'action'],
+        properties: {
+          title: { type: 'string' },
+          severity: { enum: ['blocker', 'needs-update', 'nice-to-have', 'informational'] },
+          kind: {
+            enum: ['CODE', 'OPS'],
+            description: 'CODE = needs a crew to implement. OPS = a merge/close/delete/review the captain does directly.',
+          },
+          detail: { type: 'string', description: 'Concrete evidence: version numbers, PR numbers, file:line, command output' },
+          action: { type: 'string', description: 'The specific next step. "none" if no action needed.' },
+          breaksForks: { type: 'boolean', description: 'Would this change propagate to sync targets and need coordination?' },
+        },
+      },
+    },
+    checkedClean: { type: 'string', description: 'What you checked and found healthy, so silence is not mistaken for verified.' },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Audit prompts
+// ---------------------------------------------------------------------------
+
+const primaryAudit = `${GUARDRAILS}\n${KNOWN}
+${REPO_CONTEXT}
+
+Audit the PRIMARY repo's git/CI/review state.
+
+Run and report what you observe:
+  cd REPO_ROOT
+  git fetch --quiet && git status -sb
+  git log --oneline -10
+  git log --oneline origin/main..origin/develop | wc -l   # is develop ahead of main?
+  gh pr list --state open --json number,title,headRefName,createdAt,updatedAt,mergeable
+  gh run list --limit 20 --json name,status,conclusion,headBranch,createdAt
+
+Judge:
+1. Is main in sync with origin, tree clean?
+2. develop vs main divergence — is there merged-but-unreleased work sitting on develop?
+   (Releases ship from main; a fix stuck on develop never reaches the forks.)
+3. Open PRs: age, mergeable state, CI status. A PR whose green checks predate significant
+   base movement has a STALE signal even though it shows green — call that out.
+4. Any workflow failing repeatedly on main/develop.
+5. Deprecated action pins in .github/workflows/ (actions/checkout@master or @v3, setup-node@v3).
+
+Severity: red CI on main or a broken release path = blocker. Real PR needing review =
+needs-update. Deprecated action pin = nice-to-have.`
+
+const syncHealthAudit = `${GUARDRAILS}\n${KNOWN}
+${REPO_CONTEXT}
+
+Audit the SYNC WORKFLOWS themselves. This is the highest-value area — this project's
+sync automation has silently failed before, and a sync that reports green while doing
+nothing is the worst possible failure mode.
+
+Read every REPO_ROOT/.github/workflows/sync-*.yaml. For each:
+1. What triggers it? (push to develop w/ path filter? pull_request closed? workflow_dispatch?)
+2. What is its target, and what does it actually copy (rsync scope vs path filter — do they agree)?
+3. CRITICAL: does any git/merge/push step swallow its exit code with \`|| true\`, \`|| echo ...\`,
+   or \`continue-on-error\`? A merge whose failure is swallowed followed by an unconditional
+   push will report SUCCESS while merging nothing. Grep for this pattern specifically.
+4. Does it notify on failure (Slack step)? A sync with no notification fails invisibly.
+5. gh run list --workflow <file> --limit 10 — check conclusions AND whether runs are stuck
+   queued. Cross-check: a "success" run that pushed nothing is a false green.
+
+Also: releases are pushed to main as \`chore(release): X\` with [skip ci]. Verify whether the
+sync workflows can actually fire on a release push, or whether the trigger conditions mean
+releases never propagate to the forks at all.
+
+Any false-green sync is a BLOCKER.`
+
+const siblingsAudit = `${GUARDRAILS}\n${KNOWN}
+${REPO_CONTEXT}
+
+Audit whether the sync TARGETS have actually received what the primary has.
+
+Targets (substitute the ORG you derived above for every ORG/<repo> below):
+${SIBLINGS_TEXT}
+
+Note: v3-bulletproof-contracts is a BRANCH inside the primary repo, not a separate repo.
+Check it with: cd REPO_ROOT && git log --oneline origin/develop ^origin/v3-bulletproof-contracts | wc -l
+
+None of these siblings are locally cloned. Use \`gh api repos/ORG/<repo>/contents/<path>\` to
+read individual files for comparison, or \`gh repo clone ORG/<repo> /tmp/<repo>\` if you need a
+full local diff (clean up /tmp afterwards — see GUARDRAILS).
+
+For each target, determine CONCRETELY how far behind it is:
+  - commits behind the primary's develop/main
+  - date of its last successful sync vs the date of the last primary change to a synced path
+  - whether its .tool-versions / Scarb.toml / package.json actually match the primary's
+    (compare file contents, not just assume — a version-string-only diff is very different
+    from missing toolchain pins, and the distinction determines severity)
+
+Report one finding per target that is genuinely behind. Be precise about WHAT is missing:
+"N commits behind but the only content diff is the version string" is a much smaller problem
+than "N commits behind and missing the toolchain bump" — do not conflate them.`
+
+const upstreamAudit = `${GUARDRAILS}\n${KNOWN}
+
+Check whether pinned toolchain/dependencies have fallen behind upstream.
+
+Current pins:
+${PINS}
+
+For each, find the latest upstream release LIVE. Use:
+  gh release list --repo software-mansion/scarb --limit 5
+  gh release list --repo foundry-rs/starknet-foundry --limit 5
+  gh release list --repo 0xSpaceShard/starknet-devnet --limit 5
+  gh release list --repo OpenZeppelin/cairo-contracts --limit 5
+  npm view <pkg> version
+
+Critical project context you must weigh:
+- .tool-versions propagates to ALL sync targets and is greped by
+  sync-bulletproof-contracts.yaml to stamp a Docker image tag. A toolchain bump is therefore
+  a multi-repo coordinated change, and has broken the forks before. Set breaksForks=true.
+- snforge_std (Scarb.toml) and the starknet-foundry binary (.tool-versions) MUST move in
+  lockstep or snforge rejects the mismatch. Never recommend moving one alone.
+- If you recommend a devnet bump, VERIFY the corresponding Docker image tag actually exists
+  before saying so, or the sync workflow will emit a broken tag.
+
+Report: current vs latest, releases behind, whether the gap includes breaking changes, and
+whether it fixes something that has previously bitten this project. Skip routine patch drift
+in dev tooling — fold that into ONE informational finding, not twenty.`
+
+const smokeTest = `${GUARDRAILS}
+
+You are running an end-to-end smoke test of the published scaffold-stark toolchain against a
+LOCAL devnet (free, no testnet funds). This phase may execute commands, but must NOT modify
+the primary repo (REPO_ROOT) or any other git repository — work only inside a throwaway /tmp
+directory.
+
+Steps:
+1. Work in a throwaway dir under /tmp (e.g. /tmp/stark-smoke).
+2. Scaffold a fresh app from the CURRENTLY PUBLISHED CLI: npx create-stark@latest
+   Report which version npx actually resolves to.
+3. Install deps. Start the local devnet (starknet-devnet --seed 0, per packages/snfoundry
+   "chain" script). Confirm it is listening before proceeding.
+4. Compile and deploy the default contract to the devnet.
+5. Verify the deploy ACTUALLY landed by querying the chain independently via RPC
+   (get_class_hash_at / a view call) — do NOT trust the deploy script's own success message.
+6. IMPORTANT: also check that the scaffolded project's scripts actually resolve their imports.
+   Specifically run the verify-contracts / parse-deployments scripts, or at minimum
+   typecheck them. A published template can scaffold fine and still ship a dangling import.
+7. Tear down: stop devnet, delete the /tmp dir.
+
+Report exactly what happened at each step, including the resolved create-stark version and
+the deployed contract address. If ANY step fails, that is a blocker finding with the real
+error output — do not paper over it, and do not retry more than twice. If the toolchain
+required to run this is not installed locally, STOP and report that rather than improvising.`
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+const SMOKE = (args && args.smoke) || 'devnet' // 'devnet' | 'none'
+
+phase('Audit')
+log(`Auditing primary + sync health + ${SIBLINGS.length} targets + upstream deps (smoke: ${SMOKE})`)
+
+const auditTasks = [
+  () => agent(primaryAudit, { label: 'repo:primary', phase: 'Audit', schema: FINDINGS }).then((r) => (r ? { area: 'primary-repo', ...r } : null)),
+  () => agent(syncHealthAudit, { label: 'sync:health', phase: 'Audit', schema: FINDINGS }).then((r) => (r ? { area: 'sync-health', ...r } : null)),
+  () => agent(siblingsAudit, { label: 'sync:targets', phase: 'Audit', schema: FINDINGS }).then((r) => (r ? { area: 'sync-targets', ...r } : null)),
+  () => agent(upstreamAudit, { label: 'upstream:deps', phase: 'Audit', schema: FINDINGS }).then((r) => (r ? { area: 'upstream-deps', ...r } : null)),
+]
+
+const audits = (await parallel(auditTasks)).filter(Boolean)
+
+let smoke = null
+if (SMOKE !== 'none') {
+  phase('Smoke')
+  log('Running local devnet scaffold + deploy smoke test')
+  smoke = await agent(smokeTest, { label: 'smoke:devnet', phase: 'Smoke', schema: FINDINGS })
+  if (smoke) smoke = { area: 'smoke-devnet', ...smoke }
+} else {
+  log('Smoke test skipped (smoke: "none")')
+}
+
+const all = smoke ? [...audits, smoke] : audits
+
+phase('Synthesize')
+
+const report = await agent(
+  `You are the final synthesizer for a drift check across the scaffold-stark ecosystem.
+Below are the raw per-area audit results as JSON.
+
+${JSON.stringify(all, null, 2)}
+
+Produce a single decision-ready report:
+1. A one-sentence verdict: does anything actually need updating right now, yes or no?
+2. Findings ranked blocker > needs-update > nice-to-have. MERGE duplicates appearing in
+   multiple areas into one finding naming all affected repos.
+3. For each actionable finding, state whether it is CODE (needs a crew, and give the branch
+   name you'd suggest) or OPS (a merge, close, branch delete, or review the captain does
+   directly, and give the exact command or PR number).
+4. Flag any finding with breaksForks=true as needing coordinated multi-repo rollout — this
+   project syncs to 3 forks plus an intra-repo branch, and an unsynced toolchain bump has
+   broken them before.
+5. Explicitly list what was checked and found CLEAN, so the captain knows coverage — silence
+   is not the same as verified.
+6. Note scaffold-stark-rn is marked deferred in SIBLINGS. Report its state for awareness; do
+   not rank it as actionable unless it has materially worsened.
+
+Be blunt. If everything is fine, say so plainly rather than inventing busywork. Do not
+recommend dependency upgrades that have no concrete payoff.`,
+  { label: 'synthesize', phase: 'Synthesize', schema: FINDINGS }
+)
+
+return { verdict: report, areas: all.map((a) => a.area), smokeMode: SMOKE }

--- a/.claude/workflows/stark-drift-check.mjs
+++ b/.claude/workflows/stark-drift-check.mjs
@@ -133,7 +133,7 @@ const FINDINGS = {
           severity: { enum: ['blocker', 'needs-update', 'nice-to-have', 'informational'] },
           kind: {
             enum: ['CODE', 'OPS'],
-            description: 'CODE = needs a crew to implement. OPS = a merge/close/delete/review the captain does directly.',
+            description: 'CODE = needs a code change to implement. OPS = a merge/close/delete/review with no code change.',
           },
           detail: { type: 'string', description: 'Concrete evidence: version numbers, PR numbers, file:line, command output' },
           action: { type: 'string', description: 'The specific next step. "none" if no action needed.' },
@@ -318,13 +318,13 @@ Produce a single decision-ready report:
 1. A one-sentence verdict: does anything actually need updating right now, yes or no?
 2. Findings ranked blocker > needs-update > nice-to-have. MERGE duplicates appearing in
    multiple areas into one finding naming all affected repos.
-3. For each actionable finding, state whether it is CODE (needs a crew, and give the branch
-   name you'd suggest) or OPS (a merge, close, branch delete, or review the captain does
-   directly, and give the exact command or PR number).
+3. For each actionable finding, state whether it is CODE (needs a code change, and give the
+   branch name you'd suggest) or OPS (a merge, close, branch delete, or review with no code
+   change, and give the exact command or PR number).
 4. Flag any finding with breaksForks=true as needing coordinated multi-repo rollout — this
    project syncs to 3 forks plus an intra-repo branch, and an unsynced toolchain bump has
    broken them before.
-5. Explicitly list what was checked and found CLEAN, so the captain knows coverage — silence
+5. Explicitly list what was checked and found CLEAN, so the reader knows coverage — silence
    is not the same as verified.
 6. Note scaffold-stark-rn is marked deferred in SIBLINGS. Report its state for awareness; do
    not rank it as actionable unless it has materially worsened.

--- a/.github/workflows/release-create-stark.yaml
+++ b/.github/workflows/release-create-stark.yaml
@@ -81,6 +81,7 @@ jobs:
         run: |
           rsync -av --delete \
             --exclude='.git/' \
+            --exclude='.claude/' \
             --include='.github/' \
             --include='.github/workflows/' \
             --include='.github/workflows/main.yml' \

--- a/.github/workflows/sync-basecamp-repo.yaml
+++ b/.github/workflows/sync-basecamp-repo.yaml
@@ -113,6 +113,7 @@ jobs:
           # filesystem-level problem worth surfacing for review.
           RSYNC_LOG=$(rsync -av --delete \
             --exclude='.git/' \
+            --exclude='.claude/' \
             --include='.github/' \
             --include='.github/workflows/' \
             --include='.github/workflows/main.yml' \

--- a/.github/workflows/sync-rn-repo.yaml
+++ b/.github/workflows/sync-rn-repo.yaml
@@ -108,7 +108,7 @@ jobs:
           git checkout -B "$TEMP_BRANCH" origin/develop
 
           cp -f ../source_repo/.tool-versions ./.tool-versions
-          rsync -av ../source_repo/packages/snfoundry/ ./packages/snfoundry/
+          rsync -av --exclude='.claude/' ../source_repo/packages/snfoundry/ ./packages/snfoundry/
 
           # rn-fork rewrites: structural deltas between scaffold-stark-2 and scaffold-stark-rn.
           # Each rewrite is gated by a grep sanity check so upstream renames surface as a conflict PR

--- a/.github/workflows/sync-rn-repo.yaml
+++ b/.github/workflows/sync-rn-repo.yaml
@@ -108,6 +108,10 @@ jobs:
           git checkout -B "$TEMP_BRANCH" origin/develop
 
           cp -f ../source_repo/.tool-versions ./.tool-versions
+          # --exclude='.claude/' is a no-op today: this rsync's source is packages/snfoundry/,
+          # a subdirectory, while .claude/ lives at the repo root and is never inside that path.
+          # Kept anyway as defense-in-depth so the guard is already in place if this source is
+          # ever broadened to the full repo tree.
           rsync -av --exclude='.claude/' ../source_repo/packages/snfoundry/ ./packages/snfoundry/
 
           # rn-fork rewrites: structural deltas between scaffold-stark-2 and scaffold-stark-rn.

--- a/.github/workflows/sync-speedrun-repo.yaml
+++ b/.github/workflows/sync-speedrun-repo.yaml
@@ -108,6 +108,7 @@ jobs:
 
           rsync -av \
             --exclude='.git/' \
+            --exclude='.claude/' \
             --include='.github/' \
             --include='.github/workflows/' \
             --include='.github/workflows/main.yml' \

--- a/.gitignore
+++ b/.gitignore
@@ -18,12 +18,19 @@ package-lock.json
 !**/.env.example
 
 # local tooling / generated state (keep local, do not commit)
-# .claude/workflows/ and .claude/skills/ are intentionally tracked; nothing else under .claude/ should be.
+# Only workflow scripts and skill definitions/scripts are tracked; nothing else under .claude/ should be.
 # Must be '.claude/*' (glob), not '.claude/' — git can't re-include a path inside a
 # directory that is itself ignored, so a bare '.claude/' would make the negations below a no-op.
 .claude/*
 !.claude/workflows/
+.claude/workflows/*
+!.claude/workflows/*.mjs
 !.claude/skills/
+.claude/skills/*
+!.claude/skills/*/
+.claude/skills/*/*
+!.claude/skills/*/SKILL.md
+!.claude/skills/*/*.mjs
 
 .worktrees/
 .gitnexus/

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,12 @@ package-lock.json
 !**/.env.example
 
 # local tooling / generated state (keep local, do not commit)
-.claude/
+# .claude/workflows/ is intentionally tracked; nothing else under .claude/ should be.
+# Must be '.claude/*' (glob), not '.claude/' — git can't re-include a path inside a
+# directory that is itself ignored, so a bare '.claude/' would make the negation below a no-op.
+.claude/*
+!.claude/workflows/
+
+.worktrees/
 .gitnexus/
+target/

--- a/.gitignore
+++ b/.gitignore
@@ -18,11 +18,12 @@ package-lock.json
 !**/.env.example
 
 # local tooling / generated state (keep local, do not commit)
-# .claude/workflows/ is intentionally tracked; nothing else under .claude/ should be.
+# .claude/workflows/ and .claude/skills/ are intentionally tracked; nothing else under .claude/ should be.
 # Must be '.claude/*' (glob), not '.claude/' — git can't re-include a path inside a
-# directory that is itself ignored, so a bare '.claude/' would make the negation below a no-op.
+# directory that is itself ignored, so a bare '.claude/' would make the negations below a no-op.
 .claude/*
 !.claude/workflows/
+!.claude/skills/
 
 .worktrees/
 .gitnexus/


### PR DESCRIPTION
## What

Adds `.claude/workflows/stark-drift-check.mjs` — a reusable maintenance workflow that audits this repo and its sync targets for toolchain drift, dependency lag, sync-workflow health, and template breakage (via a local devnet scaffold+deploy smoke test).

Also hardens the paths by which anything under `.claude/` could escape this repo.

## Why the hardening

This repo is **public with 171 forks**, and its workflows rsync the tree outward:

| Path | Destination |
|---|---|
| `sync-speedrun-repo.yaml:109` | speedrunstark (full tree) |
| `sync-basecamp-repo.yaml:114` | basecamp (full tree) |
| `release-create-stark.yaml:82` | `create-stark/templates/base` → **`npm publish`** |

The last one is the widest: anything committed here can reach `templates/base`, get published to npm, and land on the disk of every user running `npx create-stark`.

## Changes

**1. Portable workflow** — no machine-specific values. Agents derive repo root via `git rev-parse --show-toplevel` and org via `git remote get-url origin`; siblings are referenced as `owner/repo` through `gh api` rather than local clone paths. Verified: `grep -c '/Users/'` → 0.

**2. `.gitignore`** — the load-bearing change:
```
.claude/*
!.claude/workflows/
!.claude/skills/
.worktrees/
.gitnexus/
target/
```
Must be `.claude/*` (glob), not `.claude/` — git cannot re-include a path inside an ignored directory, so a bare `.claude/` would silently make the negations a no-op. A comment in the file records this. `.claude/skills/` is tracked alongside `.claude/workflows/` for the same reason — both are repo automation intended to ship, not local scratch state — and the two `stark-update-phase1`/`stark-sync-phase2` skill files already on disk are committed here.

`.worktrees/` was found live during this work: 1.5 GB of untracked nested checkouts at the repo root, previously unignored.

**3. `--exclude='.claude/'` on the rsyncs** — defense-in-depth, not the primary guard. CI obtains `source_repo` via `actions/checkout`, a fresh clone of **tracked files only**, so an untracked file never reaches rsync in the first place. The exclude covers `git add -f` or a future change that broadens an rsync's source. The one in `sync-rn-repo.yaml` is a documented no-op today (its source is `packages/snfoundry/`, not the repo root) and is kept deliberately for that same reason.

## Verification

```
grep -c q3labsadmin  → 0
grep -c /Users/      → 0
git add --dry-run .claude/workflows/probe.mjs  → add '...'        (addable)
git add --dry-run .claude/probe.json           → ignored          (blocked)
```

Note `git check-ignore` was deliberately **not** used as the acceptance test. It answers
*"which pattern matched this string"*, which is not the same question as *"will git ignore
this file"*. The two diverge along four axes, all reproduced on this repo (git 2.51.0):

| Query | Result |
|---|---|
| `.claude/workflows` (dir, contains tracked files) | exit 1, empty — index is consulted by default |
| `.claude/workflows` (dir, `--no-index`) | exit 0, matches `!.claude/workflows/` — **negation match still exits 0** |
| `.claude/nonexistent` (dir, not on disk) | exit 0, matches `.claude/*` — **reports ignored for a path that would not be** |
| `.claude/workflows/file.mjs` (file) | exit 1, empty — the correct answer |

The traps: trailing-slash rules like `!.claude/workflows/` only match *directories*, and git can
only know a path is a directory if it exists on disk — so a query for a non-existent path falls
through to the exclude rule and reports the exact opposite of the real behaviour. Separately,
`check-ignore` consults the index unless `--no-index` is passed, meaning its answer depends on
tracking state, which is often the very thing you are trying to establish.

Note variable (3) is **invisible if you query a file**: for a tracked *file*, both the default
and `--no-index` return exit 1/empty. It only surfaces on the *directory* query. Anyone
reproducing the table above with a file path will wrongly conclude it does not exist.

Use `git add --dry-run <file>` instead — it reports what git will actually do, and is immune to
all four variables. **But probe with a fresh, never-committed filename**, because it has one
failure mode of its own:

| Target | Output |
|---|---|
| untracked, not ignored | `add '.claude/workflows/__probe'` |
| untracked, ignored | `The following paths are ignored by one of your .gitignore files` |
| **already tracked** | **empty, exit 0** — reads as "nothing happened" and proves nothing |

So verifying against a file already committed (e.g. `stark-drift-check.mjs` itself) returns
silence regardless of the rules. The acceptance test used here:

```sh
echo x > .claude/workflows/__probe && git add --dry-run .claude/workflows/__probe
#   -> add '.claude/workflows/__probe'                    (addable, correct)
echo x > .claude/__probe          && git add --dry-run .claude/__probe
#   -> The following paths are ignored by one of your...  (blocked, correct)
rm -f .claude/workflows/__probe .claude/__probe
```

Always query a **file inside** the directory, never the directory itself, and never one that is
already tracked. Empty output means the path is already tracked — re-run with a name that does
not exist yet.

## Not in scope

Does not fix any drift the workflow found (the stale `v3-bulletproof-contracts` sync, the rn `verify-contracts.ts` import, the release→fork sync trigger). Those are separate PRs.


