### PR TITLE
chore(toolchain): bump scarb/starknet-foundry/starknet-devnet (Phase 1 Batch 2)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-scarb 2.18.0
-starknet-foundry 0.60.0
-starknet-devnet 0.8.1
+scarb 2.20.0
+starknet-foundry 0.62.1
+starknet-devnet 0.9.1

--- a/packages/snfoundry/contracts/Scarb.lock
+++ b/packages/snfoundry/contracts/Scarb.lock
@@ -60,15 +60,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.60.0"
+version = "0.62.1"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:924358bf316e502923f6733b50e239ea37585a05dc24c5fc8dd9e45f88cf7339"
+checksum = "sha256:f029f266be8fd2e66339be3e39e1cdada308d49cc12c2f76f3f5e949668361da"
 
 [[package]]
 name = "snforge_std"
-version = "0.60.0"
+version = "0.62.1"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:32e6baabec4f9af21089bc7ca685ffea5e4164497340ecbdb99314e568029195"
+checksum = "sha256:20ef99a8f3d6515ec609499334f9b2fe86ddf9264b84156ff068f40b28994bc8"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/packages/snfoundry/contracts/Scarb.toml
+++ b/packages/snfoundry/contracts/Scarb.toml
@@ -14,7 +14,7 @@ openzeppelin_interfaces = ">=2.0.0"
 [dev-dependencies]
 openzeppelin_utils = ">=2.0.0"
 # openzeppelin_testing = "6.1.0"
-snforge_std = "0.60.0"
+snforge_std = "0.62.1"
 
 [[target.starknet-contract]]
 casm = true # taggle this to `false` to speed up compilation/script tests

--- a/packages/snfoundry/contracts/src/lib.cairo
+++ b/packages/snfoundry/contracts/src/lib.cairo
@@ -1,2 +1,1 @@
 pub mod your_contract;
-


### PR DESCRIPTION
## Summary
Phase 1 Batch 2 — coordinated Starknet toolchain bump, per `/tmp/phase1-report.md` (CODE-1/2/3). Single commit, deliberately not split into per-tool PRs.

- `.tool-versions`: `scarb` `2.18.0` → `2.20.0`, `starknet-foundry` `0.60.0` → `0.62.1`, `starknet-devnet` `0.8.1` → `0.9.1`
- `packages/snfoundry/contracts/Scarb.toml`: `snforge_std` `0.60.0` → `0.62.1`
- `Scarb.lock` regenerated to match (only the `snforge_std`/`snforge_scarb_plugin` version+checksum entries changed)

### Why these four move together
- `snforge_std` and `starknet-foundry` must be identical — they ship from the same repo/tag, and a mismatch makes snforge refuse to run.
- `starknet-foundry` 0.62.1 adds full support for Starknet v0.14.3, and `starknet-devnet` 0.9.x pulls in the same v0.14.3 RPC spec change. Shipping one without the other risks an RPC spec mismatch in local `snforge`/`sncast` fork-testing.
- `starknet-devnet` is 0.x, so 0.8→0.9 is treated as breaking by policy even though it's a minor bump.

Confirmed not touched: `starknet = ">=2.18.0"` open floor in `Scarb.toml`, OpenZeppelin Cairo deps (already current at 3.0.0), `starknet` npm package (stays `^9.4.2`).

## Verification (actual output)

Toolchain installed via asdf and confirmed to match `.tool-versions`:
```
scarb 2.20.0 (f6832b048 2026-07-23)
cairo: 2.20.0
sierra: 1.9.3
snforge 0.62.1
starknet-devnet 0.9.1
```

- `scarb build` (packages/snfoundry/contracts) — succeeded; pulled `snforge_std v0.62.1` and `snforge_scarb_plugin v0.62.1` cleanly
- `snforge test` — 2 passed, 0 failed
- `yarn install --immutable` — passed clean (this branch carries no JS dependency changes; lockfile churn was only cache-eviction noise from switching branches, no resolution errors)
- `yarn next:check-types` — exit 0, no type errors
- `yarn test:nextjs` — 34 test files passed, 277 tests passed / 9 skipped, exit 0

Not run (per brief, reserved for the captain post-merge): the 14-step smoke-test gate and the Sepolia gate (S1–S5).

## Test plan
- [x] `scarb --version`, `snforge --version`, `starknet-devnet --version` match `.tool-versions`
- [x] `scarb build && snforge test`
- [x] `yarn install --immutable`
- [x] `yarn next:check-types`
- [x] `yarn test:nextjs`