### PR TITLE
chore(sync): drop stale P rules for files deleted upstream

### DIFF
--- a/.github/sync-speedrun-filter-rules
+++ b/.github/sync-speedrun-filter-rules
@@ -31,10 +31,6 @@ P packages/nextjs/public/starkcompass-icon.svg
 P packages/nextjs/public/Starknet-icon.svg
 P packages/nextjs/public/starknet.svg
 
-# Speedrun-specific contract files
-P packages/snfoundry/contracts/tests/TestContract.cairo
-P packages/snfoundry/scripts-ts/helpers/fees.ts
-
 # Speedrun workflows
 P .github/workflows/sync_other_challenges.yaml
 


### PR DESCRIPTION
This unblocks speedrunstark's zombie TestContract.cairo cleanup. These files were deleted upstream in aa40360 (TestContract.cairo) and b9ebc9c (fees.ts) and no longer exist in scaffold-stark-2.