### PR TITLE
test(cairo): add should_panic coverage to the contract gate

### DIFF
--- a/packages/snfoundry/contracts/tests/test_contract.cairo
+++ b/packages/snfoundry/contracts/tests/test_contract.cairo
@@ -60,3 +60,33 @@ fn test_transfer() {
         ); // we transfer 500 wei
     assert(your_contract_dispatcher.greeting() == new_greeting, 'Should allow set new message');
 }
+
+#[test]
+#[fork("SEPOLIA_LATEST")]
+#[should_panic(
+    expected: ('ERC20: insufficient allowance', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'),
+)]
+fn test_set_greeting_no_allowance() {
+    let user = OWNER;
+    let your_contract_address = deploy_contract("YourContract");
+
+    let your_contract_dispatcher = IYourContractDispatcher {
+        contract_address: your_contract_address,
+    };
+
+    let new_greeting: ByteArray = "Learn Scaffold-Stark 2! :)";
+
+    cheat_caller_address(your_contract_address, user, CheatSpan::TargetCalls(1));
+    your_contract_dispatcher.set_greeting(new_greeting.clone(), Option::Some(500));
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED'))]
+fn test_withdraw_not_owner() {
+    let contract_address = deploy_contract("YourContract");
+    let dispatcher = IYourContractDispatcher { contract_address };
+
+    let not_owner: ContractAddress = 0x123.try_into().unwrap();
+    cheat_caller_address(contract_address, not_owner, CheatSpan::TargetCalls(1));
+    dispatcher.withdraw();
+}


### PR DESCRIPTION
This PR adds `#[should_panic]` test coverage for the genuine revert paths in `YourContract`, ensuring the testing gate will correctly catch regressions where a panic is expected but does not occur (like what was seen with a recent `snforge` / dependency version bump).

### Mutation-Check Evidence

To verify these tests genuinely bite, the contract's guards were temporarily removed and the tests confirmed to fail exactly for the lack of panic.

**1. `withdraw` missing ownership check mutation:**

```
[FAIL] contracts_integrationtest::test_contract::test_withdraw_not_owner

Failure data:
    Expected to panic, but no panic occurred
    Expected panic data:  [0x43616c6c6572206973206e6f7420746865206f776e6572, 0x454e545259504f494e545f4641494c4544] (Caller is not the owner, ENTRYPOINT_FAILED)
```

**2. `set_greeting` skipped ERC20 allowance check mutation:**

```
[FAIL] contracts_integrationtest::test_contract::test_set_greeting_no_allowance

Failure data:
    Expected to panic, but no panic occurred
    Expected panic data:  [0x45524332303a20696e73756666696369656e7420616c6c6f77616e6365, 0x454e545259504f494e545f4641494c4544, 0x454e545259504f494e545f4641494c4544] (ERC20: insufficient allowance, ENTRYPOINT_FAILED, ENTRYPOINT_FAILED)
```

The tests have verified to pass when the contract is in its correct original state.
