### PR TITLE
ci: Add check to ensure starknet-foundry and snforge_std versions are in sync

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,24 @@ jobs:
       - name: Check starknet-foundry version sync
         run: |
           TOOL_VER=$(grep 'starknet-foundry' .tool-versions | awk '{print $2}' | tr -d '\r')
-          SCARB_VER=$(grep -E '^snforge_std\s*=\s*' packages/snfoundry/contracts/Scarb.toml | sed -n 's/.*"\([^"]*\)".*/\1/p' | tr -d '\r')
+          
+          if [ ! -f "packages/snfoundry/contracts/Scarb.lock" ]; then
+            echo "Error: Scarb.lock not found. Cannot determine resolved snforge_std version."
+            exit 1
+          fi
+          
+          SCARB_VER=$(awk '/name = "snforge_std"/{f=1} f && /^version = /{gsub(/"/,"",$3); print $3; exit}' packages/snfoundry/contracts/Scarb.lock | tr -d '\r')
+          
+          if [ -z "$SCARB_VER" ]; then
+            echo "Error: snforge_std not found in Scarb.lock. Cannot determine resolved version."
+            exit 1
+          fi
+          
           echo "starknet-foundry in .tool-versions: $TOOL_VER"
-          echo "snforge_std in Scarb.toml: $SCARB_VER"
+          echo "snforge_std in Scarb.lock: $SCARB_VER"
+          
           if [ "$TOOL_VER" != "$SCARB_VER" ]; then
-            echo "Error: Version mismatch! .tool-versions has starknet-foundry $TOOL_VER but Scarb.toml has snforge_std $SCARB_VER"
+            echo "Error: Version mismatch! .tool-versions has starknet-foundry $TOOL_VER but Scarb.lock resolved snforge_std $SCARB_VER"
             exit 1
           fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
+      - name: Check starknet-foundry version sync
+        run: |
+          TOOL_VER=$(grep 'starknet-foundry' .tool-versions | awk '{print $2}' | tr -d '\r')
+          SCARB_VER=$(grep -E '^snforge_std\s*=\s*' packages/snfoundry/contracts/Scarb.toml | sed -n 's/.*"\([^"]*\)".*/\1/p' | tr -d '\r')
+          echo "starknet-foundry in .tool-versions: $TOOL_VER"
+          echo "snforge_std in Scarb.toml: $SCARB_VER"
+          if [ "$TOOL_VER" != "$SCARB_VER" ]; then
+            echo "Error: Version mismatch! .tool-versions has starknet-foundry $TOOL_VER but Scarb.toml has snforge_std $SCARB_VER"
+            exit 1
+          fi
+
       - name: Setup node env
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,15 @@ jobs:
         run: yarn compile
 
       - name: Run smart contract tests
-        run: yarn test
+        run: |
+          set -o pipefail
+          yarn test 2>&1 | tee test_output.log
+          TEST_EXIT=${PIPESTATUS[0]}
+          if grep -i "snforge_std" test_output.log | grep -iq "version requirement"; then
+            echo "Error: snforge_std version mismatch warning detected by snforge!"
+            exit 1
+          fi
+          exit $TEST_EXIT
 
       - name: Check Code Format
         run: yarn format:check


### PR DESCRIPTION
Added CI checks to ensure \`starknet-foundry\` and \`snforge_std\` versions are properly synced, preventing silent test failures due to unsupported version combinations.

### 1. Widen the check (Catching exact warnings)
Equality checking is a proxy for what we actually care about. The real failure happens when an unsupported combination silently passes broken tests. 

To address the root cause, I've widened the check to detect when `snforge` itself emits the `Package snforge_std version does not meet the recommended version requirement` warning. The script now captures `yarn test` output and looks for this warning using a tolerant `grep -i "snforge_std" ... | grep -iq "version requirement"`. If found, the CI step forcefully exits with code `1`, causing the pipeline to fail and block the mismatched combination.

### 2. Fix false positives in the equality check
The equality proxy check originally read the declared version string from `Scarb.toml`. However, this produces false positives when a project declares a range (e.g., `>=0.49.0`), even if that range resolves to exactly the same version used in `.tool-versions`.

To fix this, the equality check now extracts the **resolved** version from `Scarb.lock` instead of the declared string in `Scarb.toml`. This handles floors, carets, and exact pins correctly. It also includes safeguards that will fail the build with clear error messages if `Scarb.lock` is missing entirely or if `snforge_std` cannot be found in the lock file. Both the equality proxy check (now against `Scarb.lock`) and the direct snforge warning check are active and enforce a hard CI block (`exit 1`) on mismatch.

---
### Verification Evidence

#### 1. Passing run (Synced versions: .tool-versions 0.62.1, Scarb.lock resolves 0.62.1)
```bash
# Equality Check output:
starknet-foundry in .tool-versions: 0.62.1
snforge_std in Scarb.lock: 0.62.1
(Exit code: 0)

# Warning Detection output:
   Compiling test(contracts_unittest) contracts v0.2.0
   Compiling test(contracts_integrationtest) contracts_integrationtest v0.2.0
    Finished `dev` profile target(s) in 2 seconds

Collected 2 test(s) from contracts package
Running 0 test(s) from src/
Running 2 test(s) from tests/
[PASS] contracts_integrationtest::test_contract::test_set_greetings (l1_gas: ~0, l1_data_gas: ~576, l2_gas: ~3766935)
[PASS] contracts_integrationtest::test_contract::test_transfer (l1_gas: ~0, l1_data_gas: ~832, l2_gas: ~5858524)
Tests: 2 passed, 0 failed, 0 ignored, 0 filtered out
(Exit code: 0)
```

#### 2. False Positive fix (Range in Scarb.toml: >=0.49.0, Scarb.lock resolves: 0.62.1)
```bash
# Simulating a declared range that resolves correctly
starknet-foundry in .tool-versions: 0.62.1
snforge_std in Scarb.lock: 0.62.1
(Exit code: 0)  <-- The check now PASSES where the old version would have failed
```

#### 3. Genuine mismatch (Lock resolves differently: Scarb.lock 0.60.0)
```bash
# Simulating a genuine mismatch where the lock resolves something else
starknet-foundry in .tool-versions: 0.62.1
snforge_std in Scarb.lock: 0.60.0
Error: Version mismatch! .tool-versions has starknet-foundry 0.62.1 but Scarb.lock resolved snforge_std 0.60.0
(Exit code: 1)
```

#### 4. Post-verification check
```bash
git diff develop -- .tool-versions packages/snfoundry/contracts/Scarb.toml packages/snfoundry/contracts/Scarb.lock
# (Returns empty, confirming files are byte-identical to develop)
```
