### PR TITLE
docs(readme): correct Compatible versions and assert it against .tool-versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,28 @@ jobs:
             exit 1
           fi
 
+      - name: Check README versions sync
+        run: |
+          SCARB_VER=$(grep 'scarb' .tool-versions | awk '{print $2}' | tr -d '\r')
+          SNFORGE_VER=$(grep 'starknet-foundry' .tool-versions | awk '{print $2}' | tr -d '\r')
+          DEVNET_VER=$(grep 'starknet-devnet' .tool-versions | awk '{print $2}' | tr -d '\r')
+          
+          COMPAT_BLOCK=$(awk '/^## Compatible versions/{flag=1; print; next} /^## /{if(flag) flag=0} flag' README.md)
+          
+          if ! echo "$COMPAT_BLOCK" | grep -q "\- Scarb - v$SCARB_VER"; then
+            echo "Error: README.md 'Compatible versions' block does not have '- Scarb - v$SCARB_VER'"
+            exit 1
+          fi
+          
+          if ! echo "$COMPAT_BLOCK" | grep -q "\- Snforge - v$SNFORGE_VER"; then
+            echo "Error: README.md 'Compatible versions' block does not have '- Snforge - v$SNFORGE_VER'"
+            exit 1
+          fi
+          
+          if ! echo "$COMPAT_BLOCK" | grep -q "\- Starknet-devnet - v$DEVNET_VER"; then
+            echo "Error: README.md 'Compatible versions' block does not have '- Starknet-devnet - v$DEVNET_VER'"
+            exit 1
+          fi
       - name: Setup node env
         uses: actions/setup-node@v3
         with:
@@ -68,6 +90,16 @@ jobs:
         with:
           tool-versions: ./.tool-versions
           scarb-lock: ./packages/snfoundry/contracts/Scarb.lock
+
+      - name: Check README Cairo version sync
+        run: |
+          CAIRO_VER=$(scarb --version | awk '/^cairo:/{print $2}' | tr -d '\r')
+          COMPAT_BLOCK=$(awk '/^## Compatible versions/{flag=1; print; next} /^## /{if(flag) flag=0} flag' README.md)
+          
+          if ! echo "$COMPAT_BLOCK" | grep -q "\- Cairo - v$CAIRO_VER"; then
+            echo "Error: README.md 'Compatible versions' block does not have '- Cairo - v$CAIRO_VER'"
+            exit 1
+          fi
 
       - name: Install snfoundryup
         uses: foundry-rs/setup-snfoundry@v3

--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ Now you are ready!!!
 
 ## Compatible versions
 
-- Starknet-devnet - v0.7.2
-- Scarb - v2.15.1
-- Snforge - v0.55.0
-- Cairo - v2.15.0
+- Starknet-devnet - v0.9.1
+- Scarb - v2.20.0
+- Snforge - v0.62.1
+- Cairo - v2.20.0
 - Rpc - v0.10.x
 
 ## Quickstart 1: Deploying a Smart Contract to Starknet-Devnet


### PR DESCRIPTION
The `README.md` ships inside the published `create-stark` npm package, so every `npx create-stark` user reads it. The "Compatible versions" block was last updated in February 2026, while the `.tool-versions` was bumped four times since then.

Because of this drift, users were being told to install an old version of Scarb that cannot build the latest template, leading to compilation failures and confusion out of the box.

This PR:
1. Updates the `README.md` Compatible versions block to match the current `.tool-versions`.
2. Adds CI steps in `.github/workflows/main.yml` to assert that the `README.md` versions always stay in sync with the toolchain to ensure it can never silently drift again.
   - For Scarb, Snforge, and Devnet, we check against `.tool-versions` directly after Checkout.
   - For Cairo, we check against the *actual* resolved Cairo version extracted from `scarb --version` after Scarb is installed. This prevents false positives, since the Cairo version isn't always exactly the same as the Scarb version (e.g. `Scarb v2.15.1` used `Cairo v2.15.0`).
   - The grep statements are explicitly anchored to the `## Compatible versions` block to ensure precision.
   - (The RPC version is currently excluded from CI checks as it is not managed via the toolchain).

### Verification
```
--- 1. assert pass trên README đã sửa ---
Assert PASS!

--- 2. cố tình đặt sai 1 giá trị -> confirm fail kèm thông báo ---
EXPECTED FAILURE: README.md 'Compatible versions' block does not have '- Scarb - v2.20.0'

--- 3. 'git diff develop -- .tool-versions' phải RỖNG ---
(rỗng)
```
