### PR TITLE
fix(ci): add root-level dependency files to Next.js CI path filters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "packages/snfoundry/contracts/**"
       - "packages/nextjs/**"
+      - "yarn.lock"
+      - "package.json"
+      - ".tool-versions"
   pull_request:
     branches:
       - main
@@ -12,6 +15,9 @@ on:
     paths:
       - "packages/nextjs/**"
       - "packages/snfoundry/**"
+      - "yarn.lock"
+      - "package.json"
+      - ".tool-versions"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Adds `yarn.lock`, `package.json`, and `.tool-versions` to both the `push` and `pull_request` path filters in `.github/workflows/main.yml`, so changes to these root-level dependency/toolchain files trigger CI.

Originally identified and requested by the speedrun-stark captain.

## Motivation

**1. Upstream gap.** The root `.tool-versions`, `package.json`, and `yarn.lock` files all exist in this repo but appeared in neither the `push` nor `pull_request` path filters, so a dependency or toolchain bump touching only those files silently skipped CI entirely. Concrete evidence: our recent toolchain bump and the checks added in PRs #732/#734 did not run CI on their own PRs, for exactly this reason.

**2. Cannot be fixed downstream.** `scaffold-stark-2` syncs `.github/workflows/main.yml` into `Scaffold-Stark/speedrunstark` via a raw rsync overwrite (`.github/workflows/sync-speedrun-repo.yaml`, `--include='.github/workflows/main.yml'`). speedrunstark merged this exact fix locally as their PR #366 on 2026-07-30, and our 02:15 UTC sync on 2026-07-31 overwrote it on all 7 of their branches. The fix has to live here upstream, or it will keep being erased on every sync.

## Scope

This PR touches only the `on:` path filters. It does not touch the "Check README versions sync" / "Check README Cairo version sync" steps — that fix is already in flight separately as PR #735.

## Test plan

- [x] `git diff --numstat origin/develop -- .github/workflows/main.yml` → `6	0	.github/workflows/main.yml`
- [x] Verified YAML parses correctly and both path lists contain `yarn.lock`, `package.json`, and `.tool-versions`