### PR TITLE
fix: widen-safe mainnetFork typing and replace dead Blast RPC endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -602,8 +602,8 @@ Also configure RPC URLs in `packages/nextjs/.env`:
 
 ```
 NEXT_PUBLIC_DEVNET_PROVIDER_URL=http://127.0.0.1:5050
-NEXT_PUBLIC_SEPOLIA_PROVIDER_URL=https://starknet-sepolia.public.blastapi.io/rpc/v0_9
-NEXT_PUBLIC_MAINNET_PROVIDER_URL=https://starknet-mainnet.public.blastapi.io/rpc/v0_9
+NEXT_PUBLIC_SEPOLIA_PROVIDER_URL=https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU
+NEXT_PUBLIC_MAINNET_PROVIDER_URL=https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU
 ```
 
 #### 3. Deploy your smart contract(s)

--- a/packages/nextjs/services/web3/websocket.ts
+++ b/packages/nextjs/services/web3/websocket.ts
@@ -40,7 +40,7 @@ export const getWsUrlForChain = (chain: Chain): string => {
         sepoliaWs ||
         httpToWs(
           chain.rpcUrls.public.http[0] ||
-            "https://starknet-sepolia.public.blastapi.io/rpc/v0_9",
+            "https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU",
         )
       );
     case "mainnet":
@@ -48,7 +48,7 @@ export const getWsUrlForChain = (chain: Chain): string => {
         mainnetWs ||
         httpToWs(
           chain.rpcUrls.public.http[0] ||
-            "https://starknet-mainnet.public.blastapi.io/rpc/v0_9",
+            "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU",
         )
       );
     default:

--- a/packages/nextjs/supportedChains.ts
+++ b/packages/nextjs/supportedChains.ts
@@ -28,7 +28,7 @@ const mainnetFork = {
       http: [rpcUrlDevnet],
     },
   },
-} as chains.Chain;
+} as const satisfies chains.Chain;
 
 const devnet = {
   ...chains.devnet,


### PR DESCRIPTION
## Summary

Two upstream defects found during basecamp hackathon verification:

**1. `mainnetFork` type widening breaks `targetNetworks: [chains.mainnetFork]` (check-types failure)**

`packages/nextjs/supportedChains.ts` asserted `mainnetFork` `as chains.Chain`, which widens the `network: "devnet"` literal to plain `string`. That breaks the literal-type indexing that `packages/nextjs/utils/scaffold-stark/contract.ts` relies on, producing 9 type errors whenever `scaffold.config.ts` targets `mainnetFork` — including `ContractUI.tsx:69` ("Implicit conversion of a symbol to a string will fail at runtime") and `contract.ts:56` (`MergeDeepRecord` index-signature failure). Fixed by aligning `mainnetFork` with the existing `devnet` object's `as const satisfies chains.Chain` form. No field values changed — assertion only.

Evidence: basecamp's step-3 branch sets `targetNetworks: [chains.mainnetFork]` and its build/check-types have never passed. This was re-tested against a **live Alchemy mainnet fork** (`--fork-block 1540452`) and failed identically, proving it's a pure compile-time type bug with no network dependency.

**2. Dead Blast Starknet RPC endpoints**

Blast's Starknet RPC is decommissioned. Verified live: `POST https://starknet-mainnet.public.blastapi.io/rpc/v0_9` returns a well-formed JSON-RPC error envelope (code `-32000`, `"Blast API is no longer available. Please update your integration to use Alchemy's API instead."`) rather than refusing the connection — Sepolia behaves identically. Callers hit confusing parse errors instead of a clear "unreachable" failure. Replaced the two fallback URLs in `websocket.ts` and the matching example in `AGENTS.md` with the Alchemy endpoints this repo already ships in `packages/snfoundry/.env.example` (`RPC_URL_SEPOLIA` / `RPC_URL_MAINNET` — a shared public demo RPC gateway key, not a signing key).

Left untouched (different, live service): the Blastapi **faucet** links in `README.md:228` and `FaucetSepolia.tsx:32`, and the keyed blastapi URL used as a string fixture in `services/web3/__test__/provider.test.ts`.

## Changes
- `packages/nextjs/supportedChains.ts` (1 line): `mainnetFork` assertion → `as const satisfies chains.Chain`
- `packages/nextjs/services/web3/websocket.ts` (2 lines): sepolia/mainnet fallback RPC URLs → Alchemy
- `AGENTS.md` (2 lines): example env values → Alchemy

## Test plan
- [x] `yarn next:check-types` with `scaffold.config.ts` unchanged (`targetNetworks: [chains.devnet]`) → exit 0
- [x] Reproduced the pre-fix bug: with the old `as chains.Chain` assertion and `targetNetworks: [chains.mainnetFork]`, `yarn next:check-types` fails with exit 1 and the exact 9 errors described above
- [x] With the fix applied and `targetNetworks: [chains.mainnetFork]`, `yarn next:check-types` passes with exit 0
- [x] `scaffold.config.ts` reverted to its original state afterward — confirmed via `git status`/`git diff`, does not appear in this PR's diff
- [ ] CI: this PR now gets Next.js CI since root dep files are in the path filters, but the `AGENTS.md`-only and non-`packages/nextjs`-code-only nature of parts of this diff may not trigger every workflow — hand-verified above regardless; will report actual CI runs on this PR once available