### PR TITLE
fix: run CI on pull requests that change workflow files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ on:
       - "yarn.lock"
       - "package.json"
       - ".tool-versions"
+      - ".github/workflows/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

`.github/workflows/**` was excluded from both the `push` and `pull_request` path filters in `main.yml`, so a pull request that only changed a workflow file never ran CI. Concretely, on 2026-07-31: PR #734 changed `README.md` and `main.yml`, neither path matched the filters, CI did not run, and a broken awk-based version assertion shipped to `develop` and then propagated to the `basecamp` and `speedrunstark` forks. The follow-up fixes, PR #735 and PR #736 (the earlier path-filter fix), also landed with zero CI coverage and had to be hand-verified.

This PR adds `.github/workflows/**` to the `pull_request` paths list only, so future PRs that touch workflow files get CI coverage at review time.

## Why `pull_request` only, not `push`

This asymmetry is intentional, not an oversight:

- `main.yml` is rsynced to the `Scaffold-Stark/basecamp` and `Scaffold-Stark/speedrunstark` forks (via `--include='.github/workflows/main.yml'` in `sync-basecamp-repo.yaml` and `sync-speedrun-repo.yaml`). Both forks have 8 branches each, and several are legitimately red (learner checkpoint stubs, a known empty-`deployedContracts` build failure).
- Sync commits land in those forks as **pushes**. If `.github/workflows/**` were also added to the `push` paths list, every sync touching `main.yml` would trigger full CI across all fork branches and re-report their pre-existing known-red state on every sync wave. That's noise this repo would be creating, not a real regression it would be catching.
- `scaffold-stark-rn` and `v3-bulletproof-contracts` do not receive `main.yml` via sync, so they're unaffected either way.

**Known limitation being accepted:** forks still won't run CI when a sync changes only `main.yml`, so they can't self-verify a synced workflow change. That's deliberate — the fix for that belongs on the fork side (e.g. a `workflow_dispatch` trigger), not by pushing CI noise into every fork branch from here.

## Note on this PR's own CI

This PR itself touches `.github/workflows/**`, which is exactly the kind of change the new filter is meant to catch — but the filter change only takes effect after merging to `develop`. So CI is **not** expected to run on this PR itself; that's expected, not a bug.

## Test plan

- [x] `git diff --numstat origin/develop -- .github/workflows/main.yml` → `1	0	.github/workflows/main.yml` (exactly one line added, none removed, one file changed)
- [x] Parsed the resulting YAML with PyYAML and confirmed `push.paths` is unchanged and `pull_request.paths` gained exactly `.github/workflows/**`