### PR TITLE
release: v3.1.1 — dead RPC endpoints, mainnetFork typing, CI correctness

### DIFF
--- a/.github/sync-speedrun-filter-rules
+++ b/.github/sync-speedrun-filter-rules
@@ -31,10 +31,6 @@ P packages/nextjs/public/starkcompass-icon.svg
 P packages/nextjs/public/Starknet-icon.svg
 P packages/nextjs/public/starknet.svg
 
-# Speedrun-specific contract files
-P packages/snfoundry/contracts/tests/TestContract.cairo
-P packages/snfoundry/scripts-ts/helpers/fees.ts
-
 # Speedrun workflows
 P .github/workflows/sync_other_challenges.yaml
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ on:
       - "yarn.lock"
       - "package.json"
       - ".tool-versions"
+      - ".github/workflows/**"
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
+      - name: Check starknet-foundry version sync
+        run: |
+          TOOL_VER=$(grep 'starknet-foundry' .tool-versions | awk '{print $2}' | tr -d '\r')
+          
+          if [ ! -f "packages/snfoundry/contracts/Scarb.lock" ]; then
+            echo "Error: Scarb.lock not found. Cannot determine resolved snforge_std version."
+            exit 1
+          fi
+          
+          SCARB_VER=$(awk '/name = "snforge_std"/{f=1} f && /^version = /{gsub(/"/,"",$3); print $3; exit}' packages/snfoundry/contracts/Scarb.lock | tr -d '\r')
+          
+          if [ -z "$SCARB_VER" ]; then
+            echo "Error: snforge_std not found in Scarb.lock. Cannot determine resolved version."
+            exit 1
+          fi
+          
+          echo "starknet-foundry in .tool-versions: $TOOL_VER"
+          echo "snforge_std in Scarb.lock: $SCARB_VER"
+          
+          if [ "$TOOL_VER" != "$SCARB_VER" ]; then
+            echo "Error: Version mismatch! .tool-versions has starknet-foundry $TOOL_VER but Scarb.lock resolved snforge_std $SCARB_VER"
+            exit 1
+          fi
+
       - name: Setup node env
         uses: actions/setup-node@v3
         with:
@@ -54,7 +78,15 @@ jobs:
         run: yarn compile
 
       - name: Run smart contract tests
-        run: yarn test
+        run: |
+          set -o pipefail
+          yarn test 2>&1 | tee test_output.log
+          TEST_EXIT=${PIPESTATUS[0]}
+          if grep -i "snforge_std" test_output.log | grep -iq "version requirement"; then
+            echo "Error: snforge_std version mismatch warning detected by snforge!"
+            exit 1
+          fi
+          exit $TEST_EXIT
 
       - name: Check Code Format
         run: yarn format:check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "packages/snfoundry/contracts/**"
       - "packages/nextjs/**"
+      - "yarn.lock"
+      - "package.json"
+      - ".tool-versions"
   pull_request:
     branches:
       - main
@@ -12,6 +15,9 @@ on:
     paths:
       - "packages/nextjs/**"
       - "packages/snfoundry/**"
+      - "yarn.lock"
+      - "package.json"
+      - ".tool-versions"
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,8 +59,13 @@ jobs:
           SNFORGE_VER=$(grep 'starknet-foundry' .tool-versions | awk '{print $2}' | tr -d '\r')
           DEVNET_VER=$(grep 'starknet-devnet' .tool-versions | awk '{print $2}' | tr -d '\r')
           
-          COMPAT_BLOCK=$(awk '/^## Compatible versions/{flag=1; print; next} /^## /{if(flag) flag=0} flag' README.md)
-          
+          COMPAT_BLOCK=$(awk '/^#+ Compatible versions/{flag=1; print; next} /^#+ /{if(flag) flag=0} flag' README.md)
+
+          if [ -z "$COMPAT_BLOCK" ]; then
+            echo "::notice::No 'Compatible versions' heading found in README.md — skipping README version sync assertions."
+            exit 0
+          fi
+
           if ! echo "$COMPAT_BLOCK" | grep -q "\- Scarb - v$SCARB_VER"; then
             echo "Error: README.md 'Compatible versions' block does not have '- Scarb - v$SCARB_VER'"
             exit 1
@@ -94,8 +99,13 @@ jobs:
       - name: Check README Cairo version sync
         run: |
           CAIRO_VER=$(scarb --version | awk '/^cairo:/{print $2}' | tr -d '\r')
-          COMPAT_BLOCK=$(awk '/^## Compatible versions/{flag=1; print; next} /^## /{if(flag) flag=0} flag' README.md)
-          
+          COMPAT_BLOCK=$(awk '/^#+ Compatible versions/{flag=1; print; next} /^#+ /{if(flag) flag=0} flag' README.md)
+
+          if [ -z "$COMPAT_BLOCK" ]; then
+            echo "::notice::No 'Compatible versions' heading found in README.md — skipping README Cairo version sync assertion."
+            exit 0
+          fi
+
           if ! echo "$COMPAT_BLOCK" | grep -q "\- Cairo - v$CAIRO_VER"; then
             echo "Error: README.md 'Compatible versions' block does not have '- Cairo - v$CAIRO_VER'"
             exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,28 @@ jobs:
             exit 1
           fi
 
+      - name: Check README versions sync
+        run: |
+          SCARB_VER=$(grep 'scarb' .tool-versions | awk '{print $2}' | tr -d '\r')
+          SNFORGE_VER=$(grep 'starknet-foundry' .tool-versions | awk '{print $2}' | tr -d '\r')
+          DEVNET_VER=$(grep 'starknet-devnet' .tool-versions | awk '{print $2}' | tr -d '\r')
+          
+          COMPAT_BLOCK=$(awk '/^## Compatible versions/{flag=1; print; next} /^## /{if(flag) flag=0} flag' README.md)
+          
+          if ! echo "$COMPAT_BLOCK" | grep -q "\- Scarb - v$SCARB_VER"; then
+            echo "Error: README.md 'Compatible versions' block does not have '- Scarb - v$SCARB_VER'"
+            exit 1
+          fi
+          
+          if ! echo "$COMPAT_BLOCK" | grep -q "\- Snforge - v$SNFORGE_VER"; then
+            echo "Error: README.md 'Compatible versions' block does not have '- Snforge - v$SNFORGE_VER'"
+            exit 1
+          fi
+          
+          if ! echo "$COMPAT_BLOCK" | grep -q "\- Starknet-devnet - v$DEVNET_VER"; then
+            echo "Error: README.md 'Compatible versions' block does not have '- Starknet-devnet - v$DEVNET_VER'"
+            exit 1
+          fi
       - name: Setup node env
         uses: actions/setup-node@v3
         with:
@@ -68,6 +90,16 @@ jobs:
         with:
           tool-versions: ./.tool-versions
           scarb-lock: ./packages/snfoundry/contracts/Scarb.lock
+
+      - name: Check README Cairo version sync
+        run: |
+          CAIRO_VER=$(scarb --version | awk '/^cairo:/{print $2}' | tr -d '\r')
+          COMPAT_BLOCK=$(awk '/^## Compatible versions/{flag=1; print; next} /^## /{if(flag) flag=0} flag' README.md)
+          
+          if ! echo "$COMPAT_BLOCK" | grep -q "\- Cairo - v$CAIRO_VER"; then
+            echo "Error: README.md 'Compatible versions' block does not have '- Cairo - v$CAIRO_VER'"
+            exit 1
+          fi
 
       - name: Install snfoundryup
         uses: foundry-rs/setup-snfoundry@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -602,8 +602,8 @@ Also configure RPC URLs in `packages/nextjs/.env`:
 
 ```
 NEXT_PUBLIC_DEVNET_PROVIDER_URL=http://127.0.0.1:5050
-NEXT_PUBLIC_SEPOLIA_PROVIDER_URL=https://starknet-sepolia.public.blastapi.io/rpc/v0_9
-NEXT_PUBLIC_MAINNET_PROVIDER_URL=https://starknet-mainnet.public.blastapi.io/rpc/v0_9
+NEXT_PUBLIC_SEPOLIA_PROVIDER_URL=https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU
+NEXT_PUBLIC_MAINNET_PROVIDER_URL=https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU
 ```
 
 #### 3. Deploy your smart contract(s)

--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ Now you are ready!!!
 
 ## Compatible versions
 
-- Starknet-devnet - v0.7.2
-- Scarb - v2.15.1
-- Snforge - v0.55.0
-- Cairo - v2.15.0
+- Starknet-devnet - v0.9.1
+- Scarb - v2.20.0
+- Snforge - v0.62.1
+- Cairo - v2.20.0
 - Rpc - v0.10.x
 
 ## Quickstart 1: Deploying a Smart Contract to Starknet-Devnet

--- a/packages/nextjs/services/web3/websocket.ts
+++ b/packages/nextjs/services/web3/websocket.ts
@@ -40,7 +40,7 @@ export const getWsUrlForChain = (chain: Chain): string => {
         sepoliaWs ||
         httpToWs(
           chain.rpcUrls.public.http[0] ||
-            "https://starknet-sepolia.public.blastapi.io/rpc/v0_9",
+            "https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU",
         )
       );
     case "mainnet":
@@ -48,7 +48,7 @@ export const getWsUrlForChain = (chain: Chain): string => {
         mainnetWs ||
         httpToWs(
           chain.rpcUrls.public.http[0] ||
-            "https://starknet-mainnet.public.blastapi.io/rpc/v0_9",
+            "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU",
         )
       );
     default:

--- a/packages/nextjs/supportedChains.ts
+++ b/packages/nextjs/supportedChains.ts
@@ -28,7 +28,7 @@ const mainnetFork = {
       http: [rpcUrlDevnet],
     },
   },
-} as chains.Chain;
+} as const satisfies chains.Chain;
 
 const devnet = {
   ...chains.devnet,

--- a/packages/snfoundry/contracts/Scarb.toml
+++ b/packages/snfoundry/contracts/Scarb.toml
@@ -9,7 +9,7 @@ edition = "2024_07"
 starknet = ">=2.18.0"
 openzeppelin_access = ">=3.0.0"
 openzeppelin_token = ">=3.0.0"
-openzeppelin_interfaces = ">=2.0.0"
+openzeppelin_interfaces = ">=2.0.0, <3.0.0"
 
 [dev-dependencies]
 openzeppelin_utils = ">=2.0.0"

--- a/packages/snfoundry/contracts/tests/test_contract.cairo
+++ b/packages/snfoundry/contracts/tests/test_contract.cairo
@@ -60,3 +60,33 @@ fn test_transfer() {
         ); // we transfer 500 wei
     assert(your_contract_dispatcher.greeting() == new_greeting, 'Should allow set new message');
 }
+
+#[test]
+#[fork("SEPOLIA_LATEST")]
+#[should_panic(
+    expected: ('ERC20: insufficient allowance', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'),
+)]
+fn test_set_greeting_no_allowance() {
+    let user = OWNER;
+    let your_contract_address = deploy_contract("YourContract");
+
+    let your_contract_dispatcher = IYourContractDispatcher {
+        contract_address: your_contract_address,
+    };
+
+    let new_greeting: ByteArray = "Learn Scaffold-Stark 2! :)";
+
+    cheat_caller_address(your_contract_address, user, CheatSpan::TargetCalls(1));
+    your_contract_dispatcher.set_greeting(new_greeting.clone(), Option::Some(500));
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not the owner', 'ENTRYPOINT_FAILED'))]
+fn test_withdraw_not_owner() {
+    let contract_address = deploy_contract("YourContract");
+    let dispatcher = IYourContractDispatcher { contract_address };
+
+    let not_owner: ContractAddress = 0x123.try_into().unwrap();
+    cheat_caller_address(contract_address, not_owner, CheatSpan::TargetCalls(1));
+    dispatcher.withdraw();
+}


### PR DESCRIPTION
## Highlights

Correctness release. No new features, no dependency majors — 9 commits across 8 files, all fixing things that were silently broken.

- **Dead RPC endpoints replaced** — Blast's Starknet RPC is decommissioned. It returns a well-formed JSON-RPC error envelope (`-32000`) rather than refusing the connection, so callers failed with confusing parse errors instead of a clear "unreachable". Fixed in `websocket.ts` fallbacks and `AGENTS.md`.
- **`mainnetFork` type widening fixed** — `supportedChains.ts` asserted `mainnetFork` `as chains.Chain`, widening the `network: "devnet"` literal to `string` and breaking the literal-type indexing `contract.ts` depends on. Any project targeting `mainnetFork` failed `check-types` with 9 errors.
- **README version drift now machine-asserted** — the "Compatible versions" block had been wrong for ~6 months, telling users to install Scarb `2.15.1` against a template needing `2.20.0`. Corrected and bound to `.tool-versions` by CI.
- **CI path filters corrected** — root `.tool-versions`, `package.json` and `yarn.lock` were in no filter, so toolchain bumps skipped CI entirely. Workflow changes now also get CI on pull requests.
- **Toolchain guardrails** — `starknet-foundry`/`snforge_std` version-pair check, `openzeppelin_interfaces` bounded to the 2.x line, `should_panic` coverage on the Cairo gate.

### Note on the shared Alchemy RPC key

The template ships a shared public demo endpoint so it works on first run. It is an RPC gateway key, not a signing key. For anything beyond a first run — especially workshops, where a whole room shares one rate limit — get your own free Alchemy key and set `RPC_URL_SEPOLIA` / `RPC_URL_MAINNET`.

## What's Changed
* chore(sync): drop stale P rules for files deleted upstream by @tu11aa in https://github.com/Scaffold-Stark/scaffold-stark-2/pull/729
* test(cairo): add should_panic coverage to the contract gate by @tu11aa in https://github.com/Scaffold-Stark/scaffold-stark-2/pull/731
* ci: Add check to ensure starknet-foundry and snforge_std versions are in sync by @tu11aa in https://github.com/Scaffold-Stark/scaffold-stark-2/pull/732
* chore(cairo): bound openzeppelin_interfaces to the 2.x line by @tu11aa in https://github.com/Scaffold-Stark/scaffold-stark-2/pull/733
* docs(readme): correct Compatible versions and assert it against .tool-versions by @tu11aa in https://github.com/Scaffold-Stark/scaffold-stark-2/pull/734
* fix(ci): make README compat-block version asserts heading-level agnostic by @tu11aa in https://github.com/Scaffold-Stark/scaffold-stark-2/pull/735
* fix(ci): add root-level dependency files to Next.js CI path filters by @tu11aa in https://github.com/Scaffold-Stark/scaffold-stark-2/pull/736
* fix: widen-safe mainnetFork typing and replace dead Blast RPC endpoints by @tu11aa in https://github.com/Scaffold-Stark/scaffold-stark-2/pull/737
* fix: run CI on pull requests that change workflow files by @tu11aa in https://github.com/Scaffold-Stark/scaffold-stark-2/pull/738

**Full Changelog**: https://github.com/Scaffold-Stark/scaffold-stark-2/compare/v3.1.0...v3.1.1